### PR TITLE
changed app-check logic

### DIFF
--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -979,7 +979,7 @@ function Invoke-WingetInstall {
         try {
             # Run winget list with timeout to prevent hanging
             $listProcess = Start-Process -FilePath 'winget' `
-                -ArgumentList 'list', '--exact', '-q', '--accept-source-agreements', $app.name `
+                -ArgumentList 'list', '--exact', '--id', $app.name, '--accept-source-agreements' `
                 -NoNewWindow `
                 -PassThru `
                 -RedirectStandardOutput "$env:TEMP\winget_list_output.txt" `
@@ -1007,7 +1007,7 @@ function Invoke-WingetInstall {
 
                     # Verify installation with timeout
                     $verifyProcess = Start-Process -FilePath 'winget' `
-                        -ArgumentList 'list', '--exact', '-q', '--accept-source-agreements', $app.name `
+                        -ArgumentList 'list', '--exact', '--id', $app.name, '--accept-source-agreements' `
                         -NoNewWindow `
                         -PassThru `
                         -RedirectStandardOutput "$env:TEMP\winget_verify_output.txt" `

--- a/winget-app-uninstall.ps1
+++ b/winget-app-uninstall.ps1
@@ -14,11 +14,11 @@
     The message to display
 #>
 function Write-Info {
-	param (
-		[Parameter(Mandatory = $true)]
-		[string]$Message
-	)
-	Write-Host $Message -ForegroundColor Blue
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+    Write-Host $Message -ForegroundColor Blue
 }
 
 <#
@@ -30,11 +30,11 @@ function Write-Info {
     The message to display
 #>
 function Write-Success {
-	param (
-		[Parameter(Mandatory = $true)]
-		[string]$Message
-	)
-	Write-Host $Message -ForegroundColor Green
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+    Write-Host $Message -ForegroundColor Green
 }
 
 <#
@@ -47,11 +47,11 @@ function Write-Success {
     The message to display
 #>
 function Write-WarningMessage {
-	param (
-		[Parameter(Mandatory = $true)]
-		[string]$Message
-	)
-	Write-Host $Message -ForegroundColor Yellow
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+    Write-Host $Message -ForegroundColor Yellow
 }
 
 <#
@@ -64,11 +64,11 @@ function Write-WarningMessage {
     The message to display
 #>
 function Write-ErrorMessage {
-	param (
-		[Parameter(Mandatory = $true)]
-		[string]$Message
-	)
-	Write-Host $Message -ForegroundColor Red
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+    Write-Host $Message -ForegroundColor Red
 }
 
 #------------------------------------------------Main Script------------------------------------------------
@@ -109,7 +109,7 @@ $failedApps = @()
 
 Foreach ($app in $apps) {
     try {
-        $listApp = winget list --exact -q $app.name
+        $listApp = winget list --exact --id $app.name
         if ([String]::Join('', $listApp).Contains($app.name)) {
             Write-Info "Uninstalling: $($app.name)"
             $uninstallResult = winget uninstall -e --id $app.name
@@ -181,7 +181,7 @@ function Write-Table {
     # Prompt user if requested and Out-GridView is available
     if ($PromptForGridView -and -not $UseGridView) {
         $canUseGridView = $false
-        
+
         # Check if we're in an interactive session
         if ([Environment]::UserInteractive) {
             # Check if Out-GridView is available
@@ -193,7 +193,7 @@ function Write-Table {
                 # Out-GridView not available, no need to prompt
             }
         }
-        
+
         if ($canUseGridView) {
             Write-Host ''
             $response = Read-Host 'Would you like to view the results in an interactive grid view? (Y/N)'
@@ -206,7 +206,7 @@ function Write-Table {
     # Try to use Out-GridView if requested and available
     if ($shouldUseGridView) {
         $canUseGridView = $false
-        
+
         # Check if we're in an interactive session
         if ([Environment]::UserInteractive) {
             # Check if Out-GridView is available
@@ -218,7 +218,7 @@ function Write-Table {
                 Write-WarningMessage 'Out-GridView is not available. Falling back to text output.'
             }
         }
-        
+
         if ($canUseGridView) {
             try {
                 $tableData | Out-GridView -Title $Title -Wait
@@ -246,7 +246,7 @@ function Format-AppList {
         [Parameter(Mandatory = $false)]
         [array]$AppArray
     )
-    
+
     if ($AppArray -and $AppArray.Count -gt 0) {
         return $AppArray -join ', '
     }


### PR DESCRIPTION
This pull request updates the way the scripts interact with the `winget list` command to improve accuracy when identifying applications. The main change is switching from using the `-q` argument to `--id` when specifying the application, ensuring that the command matches apps by their unique identifier rather than by name.

**Updates to application identification:**

* In `winget-app-install.ps1`, both the initial check for existing installations and the post-install verification now use `--id $app.name` instead of `-q $app.name` in the `winget list` command. This helps prevent false positives/negatives when multiple apps have similar names. [[1]](diffhunk://#diff-51486757e1adc5576a9af9e4e6dd5c04369b4f7762ad64ebe47b17018e3ceb49L982-R982) [[2]](diffhunk://#diff-51486757e1adc5576a9af9e4e6dd5c04369b4f7762ad64ebe47b17018e3ceb49L1010-R1010)
* In `winget-app-uninstall.ps1`, the uninstall logic now uses `--id $app.name` instead of `-q $app.name` when listing apps prior to removal, improving reliability for uninstall operations.