### PR TITLE
📚 Add GitHub CLI commands for PR metadata management

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -53,3 +53,21 @@ Always ensure the following metadata is set on every PR:
 - **Labels**: Assign relevant labels (e.g., `enhancement`, `bug`, `documentation`, `refactor`, `testing`)
 - **Assignees**: Assign to yourself (J-MaFf)
 - **Issues**: Link all related issues in the PR description and GitHub's linked issues feature
+
+**Using GitHub CLI to set metadata:**
+
+```bash
+# Add a single label
+gh issue edit <PR_NUMBER> --add-label "documentation"
+
+# Add multiple labels
+gh issue edit <PR_NUMBER> --add-label "documentation" --add-label "enhancement"
+
+# Assign to yourself
+gh issue edit <PR_NUMBER> --add-assignee <USERNAME>
+
+# Complete metadata setup example (add labels and assignee)
+gh issue edit 84 --add-label "documentation" --add-assignee "J-MaFf"
+```
+
+Note: Use `gh issue edit` for both issues and pull requests. Replace `<PR_NUMBER>` with the PR number and `<USERNAME>` with the GitHub username. Labels must exist in the repository; check available labels with `gh label list`.


### PR DESCRIPTION
### What does this PR do?

Updates the Copilot instructions with GitHub CLI commands for automating PR metadata (labels, assignees) setup, making it easier to enforce formatting standards across all projects.

### Why are we doing this?

The formatting standards guide was enhanced to include practical GitHub CLI commands. This PR ensures all repositories have the updated documentation with examples showing how to use `gh issue edit` for setting PR metadata.

### How should this be tested?

Review the updated `.github/copilot-instructions.md` file to confirm:
- GitHub CLI section is present with all command examples
- Examples are correct and clearly documented
- Instructions are easy to follow

### Any deployment notes?

No special deployment required. This is a documentation-only change that can be merged and used immediately.