### PR TITLE
🐛 Fix source error handling and improve error reporting

### DIFF
--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -1021,7 +1021,7 @@ function Invoke-WingetInstall {
             if (![String]::Join('', $listApp).Contains($app.name)) {
                 if (-not $WhatIf) {
                     Write-Info "Installing: $($app.name)"
-                    Start-Process winget -ArgumentList "install -e --accept-source-agreements --accept-package-agreements --id $($app.name)" -NoNewWindow -Wait
+                    Start-Process winget -ArgumentList "install -e --accept-source-agreements --accept-package-agreements --source winget --id $($app.name)" -NoNewWindow -Wait
 
                     # Verify installation with timeout
                     $verifyProcess = Start-Process -FilePath 'winget' `
@@ -1117,7 +1117,7 @@ function Invoke-WingetInstall {
                         # Skip if it's not a winget package or if it's a system component
                         if ($packageId -and $packageId -notmatch '^(ARP|MSIX)') {
                             try {
-                                $upgradeResult = & winget upgrade $packageId 2>&1
+                                $upgradeResult = & winget upgrade $packageId --source winget 2>&1
                                 $upgradeOutput = $upgradeResult | Out-String
 
                                 # Check if upgrade is available and successful

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -981,7 +981,7 @@ function Invoke-WingetInstall {
                 }
                 catch {
                     $sourceErrors += $source
-                    Write-WarningMessage "Error resetting sources for $source: $_. Continuing with installation..."
+                    Write-WarningMessage "Error resetting sources for ${source}: ${_}. Continuing with installation..."
                 }
             }
             else {

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -239,12 +239,19 @@ function Set-Sources {
             return $false
         }
 
+        # Read error output to provide better error messages
+        $errorOutput = Get-Content "$env:TEMP\winget_reset_error.txt" -ErrorAction SilentlyContinue | Where-Object { $_ -and $_.Trim() }
+
         # Check the exit code
         if ($resetProcess.ExitCode -eq 0) {
             Write-Success 'Winget sources reset successfully'
             return $true
         }
         else {
+            # Log the error details if available
+            if ($errorOutput) {
+                Write-WarningMessage "Winget source reset error details: $(($errorOutput -join ', '))"
+            }
             # Non-zero exit code, but not critical since script continues
             Write-Info "Winget source reset completed with exit code: $($resetProcess.ExitCode) (this is often not critical)"
             return $false
@@ -960,11 +967,22 @@ function Invoke-WingetInstall {
 
     # Verify sources are trusted
     $trustedSources = @('winget', 'msstore')
+    $sourceErrors = @()
     ForEach ($source in $trustedSources) {
         if (-not (Test-Source-IsTrusted -target $source)) {
             if (-not $WhatIf) {
                 Write-WarningMessage "Trusting source: $source"
-                Set-Sources
+                try {
+                    $sourceResetSuccess = Set-Sources
+                    if (-not $sourceResetSuccess) {
+                        $sourceErrors += $source
+                        Write-WarningMessage "Failed to reset sources for $source. Continuing with installation..."
+                    }
+                }
+                catch {
+                    $sourceErrors += $source
+                    Write-WarningMessage "Error resetting sources for $source: $_. Continuing with installation..."
+                }
             }
             else {
                 Write-Info "[DRY-RUN] Would trust source: $source"


### PR DESCRIPTION
### What does this PR do?
- Improves winget source reset handling by surfacing stderr details, ensuring process-kill/timeouts are tracked, and reporting failures without halting the installer.
- Pins every install/upgrade command to `--source winget`, so operations target the trusted source and reduce errors when other sources are misconfigured.
- Refreshes the Pester suite so it covers the new helpers, validates the expanded source verification logic, and asserts the explicit source flag usage.

### Why are we doing this?
Winget source errors were causing installs to fail without clear diagnostics. These changes make the script resilient to reset failures, clarify error output, force a known source, and prove the behavior through updated tests.

### How should this be tested?
1. Run `./launch.ps1` (or `./winget-app-install.ps1`) to walk through the install flow and verify winget source resets don't crash the script.
2. Confirm each package install and upgrade log includes `--source winget`.
3. Execute `pwsh -NoProfile -Command Import-Module Pester; Invoke-Pester Test-WingetAppInstall.Tests.ps1` to ensure the tests still pass locally.

### Any deployment notes?
No special deployment steps or config changes are required.

Closes #60