### PR TITLE
🐛 Fix error when running script via IEX method

### DIFF
--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -351,6 +351,31 @@ function Test-PathInEnvironment {
 
 <#
 .SYNOPSIS
+    Detects if the script is running locally or from a remote source (e.g., via IEX).
+.DESCRIPTION
+    Checks if $PSScriptRoot is non-empty and represents a valid directory.
+    Returns $true for local execution (file on disk), $false for remote execution (piped script).
+.RETURNS
+    [bool] True if running locally, False if running remotely.
+#>
+function Test-IsRunningLocally {
+    # Check if $PSScriptRoot is non-empty and valid
+    if ([string]::IsNullOrWhiteSpace($PSScriptRoot)) {
+        return $false
+    }
+
+    # Verify it's an actual directory path
+    try {
+        $null = Get-Item -LiteralPath $PSScriptRoot -ErrorAction Stop
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
+<#
+.SYNOPSIS
     Converts a command string into an array of arguments, properly handling quoted arguments.
 .DESCRIPTION
     This function takes a command string and splits it into individual arguments while
@@ -912,14 +937,19 @@ function Invoke-WingetInstall {
         Exit
     }
 
-    # Add the script directory to the PATH
+    # Add the script directory to the PATH (only if running locally)
     # Use $PSScriptRoot for reliable script directory detection (works with launcher)
-    $scriptDirectory = $PSScriptRoot
-    if (-not $WhatIf) {
-        Add-ToEnvironmentPath -PathToAdd $scriptDirectory -Scope 'User'
+    if (Test-IsRunningLocally) {
+        $scriptDirectory = $PSScriptRoot
+        if (-not $WhatIf) {
+            Add-ToEnvironmentPath -PathToAdd $scriptDirectory -Scope 'User'
+        }
+        else {
+            Write-Info "[DRY-RUN] Would add '$scriptDirectory' to User PATH"
+        }
     }
     else {
-        Write-Info "[DRY-RUN] Would add '$scriptDirectory' to User PATH"
+        Write-Info 'Skipping PATH update (remote execution detected)'
     }
 
     $apps = @(


### PR DESCRIPTION
### What does this PR do?
Fixes the error that occurs when running the script via the one-liner IEX method:
```powershell
Set-ExecutionPolicy Unrestricted -Scope Process; irm "https://raw.githubusercontent.com/J-MaFf/winget-app-setup/refs/heads/main/winget-app-install.ps1" | iex
```

The script now gracefully detects remote execution and skips PATH modification instead of throwing an error.

### Why are we doing this?
When running via IEX, `$PSScriptRoot` is empty (no local directory exists). This caused `Add-ToEnvironmentPath` to fail with:
```
Cannot bind argument to parameter 'PathToAdd' because it is an empty string.
```

Although the script continued to work, the error message confused users.

### How should this be tested?
1. **Local run (should show PATH plan):**
   ```powershell
   .\winget-app-install.ps1 -WhatIf
   ```
   Output should include: `[DRY-RUN] Would add '...' to User PATH`

2. **Remote run via IEX (should skip PATH silently):**
   ```powershell
   Set-ExecutionPolicy Unrestricted -Scope Process; irm "https://raw.githubusercontent.com/J-MaFf/winget-app-setup/refs/heads/main/winget-app-install.ps1" | iex
   ```
   Should display: `Skipping PATH update (remote execution detected)` with no errors

### Implementation details
- Added `Test-IsRunningLocally` helper function to detect execution context
- Validates that `$PSScriptRoot` is non-empty and represents a valid directory
- Wraps PATH modification logic with conditional check
- Displays informational message when skipping (for IEX runs)

Closes #65