### PR TITLE
🐛 Handle IEX non-admin elevation case

### DIFF
--- a/Test-WingetAppInstall.Tests.ps1
+++ b/Test-WingetAppInstall.Tests.ps1
@@ -2350,12 +2350,13 @@ Describe 'IEX non-admin execution behavior' {
         }
 
         $scriptPath = Join-Path $PSScriptRoot 'winget-app-install.ps1'
-        $escapedScriptPath = $scriptPath.Replace("'", "''")
+        $psStringEscapedPath = $scriptPath.Replace("'", "''")
+        $currentPowerShell = (Get-Process -Id $PID).Path
         $childCommand = @"
-Get-Content -Raw -LiteralPath '$escapedScriptPath' | Invoke-Expression
+Get-Content -Raw -LiteralPath '$psStringEscapedPath' | Invoke-Expression
 "@
 
-        $output = & pwsh -NoLogo -NoProfile -NonInteractive -Command $childCommand 2>&1 | Out-String
+        $output = & $currentPowerShell -NoLogo -NoProfile -NonInteractive -Command $childCommand 2>&1 | Out-String
         $exitCode = $LASTEXITCODE
 
         $exitCode | Should -Be 1

--- a/Test-WingetAppInstall.Tests.ps1
+++ b/Test-WingetAppInstall.Tests.ps1
@@ -2340,7 +2340,7 @@ Describe 'WhatIf Mode - Unit Tests' {
 
 Describe 'IEX non-admin execution behavior' {
     BeforeAll {
-        $script:isWindows = $env:OS -eq 'Windows_NT'
+        $script:isWindows = [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
         $script:isElevated = $false
 
         if ($script:isWindows) {

--- a/Test-WingetAppInstall.Tests.ps1
+++ b/Test-WingetAppInstall.Tests.ps1
@@ -2366,6 +2366,7 @@ Get-Content -Raw -LiteralPath '$psStringEscapedPath' | Invoke-Expression
         $output | Should -Match 'This script requires administrator privileges\.'
         $output | Should -Match 'Auto-elevation is unavailable when running through IEX/remote execution\.'
         $output | Should -Match 'Open an elevated PowerShell or Windows Terminal session and run the IEX command again\.'
+        $output | Should -Match 'Exiting in 5 seconds\.\.\.'
         $output | Should -Not -Match 'Press Enter to restart script with elevated privileges'
     }
 }

--- a/Test-WingetAppInstall.Tests.ps1
+++ b/Test-WingetAppInstall.Tests.ps1
@@ -2337,3 +2337,31 @@ Describe 'WhatIf Mode - Unit Tests' {
         }
     }
 }
+
+Describe 'IEX non-admin execution behavior' {
+    It 'Should exit with code 1 and show remote elevation guidance' -Skip:(-not $IsWindows) {
+        $isElevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+            [Security.Principal.WindowsBuiltInRole]::Administrator
+        )
+
+        if ($isElevated) {
+            Set-ItResult -Skipped -Because 'This test requires a non-elevated PowerShell session.'
+            return
+        }
+
+        $scriptPath = Join-Path $PSScriptRoot 'winget-app-install.ps1'
+        $escapedScriptPath = $scriptPath.Replace("'", "''")
+        $childCommand = @"
+Get-Content -Raw -LiteralPath '$escapedScriptPath' | Invoke-Expression
+"@
+
+        $output = & pwsh -NoLogo -NoProfile -NonInteractive -Command $childCommand 2>&1 | Out-String
+        $exitCode = $LASTEXITCODE
+
+        $exitCode | Should -Be 1
+        $output | Should -Match 'This script requires administrator privileges\.'
+        $output | Should -Match 'Auto-elevation is unavailable when running through IEX/remote execution\.'
+        $output | Should -Match 'Open an elevated PowerShell or Windows Terminal session and run the IEX command again\.'
+        $output | Should -Not -Match 'Press Enter to restart script with elevated privileges'
+    }
+}

--- a/Test-WingetAppInstall.Tests.ps1
+++ b/Test-WingetAppInstall.Tests.ps1
@@ -2339,15 +2339,18 @@ Describe 'WhatIf Mode - Unit Tests' {
 }
 
 Describe 'IEX non-admin execution behavior' {
-    It 'Should exit with code 1 and show remote elevation guidance' -Skip:(-not $IsWindows) {
-        $isElevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
-            [Security.Principal.WindowsBuiltInRole]::Administrator
-        )
+    BeforeAll {
+        $script:isWindows = $env:OS -eq 'Windows_NT'
+        $script:isElevated = $false
 
-        if ($isElevated) {
-            Set-ItResult -Skipped -Because 'This test requires a non-elevated PowerShell session.'
-            return
+        if ($script:isWindows) {
+            $script:isElevated = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+                [Security.Principal.WindowsBuiltInRole]::Administrator
+            )
         }
+    }
+
+    It 'Should exit with code 1 and show remote elevation guidance' -Skip:(-not $script:isWindows -or $script:isElevated) {
 
         $scriptPath = Join-Path $PSScriptRoot 'winget-app-install.ps1'
         $psStringEscapedPath = $scriptPath.Replace("'", "''")

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -914,8 +914,23 @@ function Invoke-WingetInstall {
         Write-ErrorMessage 'This script requires administrator privileges.'
         Write-ErrorMessage 'Auto-elevation is unavailable when running through IEX/remote execution.'
         Write-Info 'Open an elevated PowerShell or Windows Terminal session and run the IEX command again.'
-        Write-Prompt 'Press any key to exit...'
-        [void][System.Console]::ReadKey($true)
+
+        $canReadKey =
+            [Environment]::UserInteractive -and
+            $null -ne $Host.UI -and
+            $null -ne $Host.UI.RawUI -and
+            -not [System.Console]::IsInputRedirected
+
+        if ($canReadKey) {
+            Write-Prompt 'Press any key to exit...'
+            try {
+                [void][System.Console]::ReadKey($true)
+            }
+            catch [System.InvalidOperationException] {
+                # No attached console or redirected input; continue to the intended exit code.
+            }
+        }
+
         Exit 1
     }
     else {

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -914,23 +914,6 @@ function Invoke-WingetInstall {
         Write-ErrorMessage 'This script requires administrator privileges.'
         Write-ErrorMessage 'Auto-elevation is unavailable when running through IEX/remote execution.'
         Write-Info 'Open an elevated PowerShell or Windows Terminal session and run the IEX command again.'
-
-        $canReadKey =
-            [Environment]::UserInteractive -and
-            $null -ne $Host.UI -and
-            $null -ne $Host.UI.RawUI -and
-            -not [System.Console]::IsInputRedirected
-
-        if ($canReadKey) {
-            Write-Prompt 'Press any key to exit...'
-            try {
-                [void][System.Console]::ReadKey($true)
-            }
-            catch [System.InvalidOperationException] {
-                # No attached console or redirected input; continue to the intended exit code.
-            }
-        }
-
         Exit 1
     }
     else {

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -914,6 +914,8 @@ function Invoke-WingetInstall {
         Write-ErrorMessage 'This script requires administrator privileges.'
         Write-ErrorMessage 'Auto-elevation is unavailable when running through IEX/remote execution.'
         Write-Info 'Open an elevated PowerShell or Windows Terminal session and run the IEX command again.'
+        Write-Prompt 'Press any key to exit...'
+        [void][System.Console]::ReadKey($true)
         Exit 1
     }
     else {

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -902,11 +902,19 @@ function Invoke-WingetInstall {
 
     # Check if the script is run as administrator
     If (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')) {
-        Write-ErrorMessage 'This script requires administrator privileges. Press Enter to restart script with elevated privileges.'
-        Pause
-        # Relaunch the script with administrator privileges
-        Restart-WithElevation -PowerShellExecutable $psExecutable -ScriptPath $PSCommandPath | Out-Null
-        Exit
+        if (Test-IsRunningLocally) {
+            Write-ErrorMessage 'This script requires administrator privileges. Press Enter to restart script with elevated privileges.'
+            Pause
+            # Relaunch the script with administrator privileges
+            Restart-WithElevation -PowerShellExecutable $psExecutable -ScriptPath $PSCommandPath | Out-Null
+            Exit
+        }
+
+        # IEX/remote execution has no local script path to relaunch from.
+        Write-ErrorMessage 'This script requires administrator privileges.'
+        Write-ErrorMessage 'Auto-elevation is unavailable when running through IEX/remote execution.'
+        Write-Info 'Open an elevated PowerShell or Windows Terminal session and run the IEX command again.'
+        Exit 1
     }
     else {
         Write-Success 'Starting...'

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -914,6 +914,8 @@ function Invoke-WingetInstall {
         Write-ErrorMessage 'This script requires administrator privileges.'
         Write-ErrorMessage 'Auto-elevation is unavailable when running through IEX/remote execution.'
         Write-Info 'Open an elevated PowerShell or Windows Terminal session and run the IEX command again.'
+        Write-Info 'Exiting in 5 seconds...'
+        Start-Sleep -Seconds 5
         Exit 1
     }
     else {


### PR DESCRIPTION
### What does this PR do?
Updates the admin privilege flow so non-admin runs through IEX/remote execution are handled clearly and safely.

When the script is run locally and not elevated, behavior is unchanged: it prompts and relaunches elevated.
When the script is run via IEX and not elevated, it now explains that auto-elevation is unavailable in remote execution and exits with code 1.

### Why are we doing this?
Issue #71 reported that IEX non-admin runs did not correctly relaunch/elevate, which could lead to confusing failures later when winget operations require admin rights.

Because IEX execution has no local script file path, `Restart-WithElevation` cannot relaunch the script using `-File` in that scenario.

### How should this be tested?
1. Local non-admin run:
   - Execute `./winget-app-install.ps1`
   - Confirm it prompts for elevation and relaunches
2. IEX non-admin run:
   - Execute IEX one-liner from a non-admin shell
   - Confirm clear guidance is shown and script exits with code 1
3. Elevated run:
   - Confirm normal flow still starts successfully

### Any deployment notes?
No deployment changes required.

Closes #71