### PR TITLE
🐛 Fix corrupted source data detection (issue #77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleaned up `Test-WingetAppInstall.Tests.ps1` so it no longer defines unused variables and satisfies the linter.
 - Fixed broken winget source scenario: when running as admin on a standard user account the "winget" source registration may be missing or broken; the script now detects and auto-repairs this condition instead of silently failing (#66).
 - Added Pester coverage for Windows Terminal default profile and terminal delegation configuration paths, and corrected an `IsWindows` read-only variable name collision in the test suite.
+- Fixed corrupted winget source data detection: `Test-WingetSources` now verifies source functionality with `winget source update`, detects corruption errors like `0x8a15000f`, and uses `winget source reset` as part of repair attempts (#77).
 
 ## [1.0.0] - 2025-11-07
 

--- a/Test-WingetAppInstall.Tests.ps1
+++ b/Test-WingetAppInstall.Tests.ps1
@@ -483,9 +483,16 @@ Describe 'Test-WingetSources' {
         . "$PSScriptRoot\winget-app-install.ps1"
     }
 
-    Context 'When winget sources are accessible' {
+    Context 'When winget sources are listed and functional' {
         It 'Should return true without attempting repair' {
-            Mock winget { return 'winget      https://cdn.winget.microsoft.com/cache' } -ParameterFilter { $args[0] -eq 'source' -and $args[1] -eq 'list' -and $args -contains '--disable-interactivity' }
+            Mock winget {
+                if ($args[0] -eq 'source' -and $args[1] -eq 'list') {
+                    return 'winget      https://cdn.winget.microsoft.com/cache'
+                }
+                elseif ($args[0] -eq 'source' -and $args[1] -eq 'update') {
+                    return 'Operation completed successfully'
+                }
+            }
             Mock Add-AppxPackage { }
 
             $result = Test-WingetSources
@@ -494,16 +501,26 @@ Describe 'Test-WingetSources' {
         }
     }
 
-    Context 'When winget sources are broken and repair succeeds' {
-        It 'Should attempt repair and return true after successful retry' {
-            $script:wingetSourceCallCount = 0
+    Context 'When winget source is corrupted (0x8a15000f)' {
+        It 'Should detect corruption and attempt repair with source reset' {
+            $script:updateCount = 0
             Mock winget {
-                $script:wingetSourceCallCount++
-                if ($script:wingetSourceCallCount -eq 1) {
-                    return 'msstore      https://storeedgefd.dsx.mp.microsoft.com/v9.0'
+                if ($args[0] -eq 'source' -and $args[1] -eq 'list') {
+                    return 'winget      https://cdn.winget.microsoft.com/cache'
                 }
-                return 'winget      https://cdn.winget.microsoft.com/cache'
-            } -ParameterFilter { $args[0] -eq 'source' -and $args[1] -eq 'list' -and $args -contains '--disable-interactivity' }
+                elseif ($args[0] -eq 'source' -and $args[1] -eq 'update') {
+                    $script:updateCount++
+                    if ($script:updateCount -eq 1) {
+                        # First call: corrupted data
+                        return 'Failed: 0x8a15000f Data required by the source is missing'
+                    }
+                    # After reset: works
+                    return 'Operation completed successfully'
+                }
+                elseif ($args[0] -eq 'source' -and $args[1] -eq 'reset') {
+                    return 'Source reset completed'
+                }
+            }
             Mock Add-AppxPackage { }
 
             $result = Test-WingetSources
@@ -512,9 +529,44 @@ Describe 'Test-WingetSources' {
         }
     }
 
-    Context 'When winget sources are broken and Add-AppxPackage fails' {
-        It 'Should return false and emit error messages' {
-            Mock winget { return 'msstore      https://storeedgefd.dsx.mp.microsoft.com/v9.0' } -ParameterFilter { $args[0] -eq 'source' -and $args[1] -eq 'list' -and $args -contains '--disable-interactivity' }
+    Context 'When winget sources are missing entirely' {
+        It 'Should attempt repair with source reset and Add-AppxPackage' {
+            $script:listCallCount = 0
+            Mock winget {
+                if ($args[0] -eq 'source' -and $args[1] -eq 'list') {
+                    $script:listCallCount++
+                    if ($script:listCallCount -eq 1) {
+                        # Initially: only msstore, no winget
+                        return 'msstore      https://storeedgefd.dsx.mp.microsoft.com/v9.0'
+                    }
+                    # After repair: winget source is restored
+                    return 'winget      https://cdn.winget.microsoft.com/cache'
+                }
+                elseif ($args[0] -eq 'source' -and $args[1] -eq 'update') {
+                    return 'Operation completed successfully'
+                }
+                elseif ($args[0] -eq 'source' -and $args[1] -eq 'reset') {
+                    return 'Source reset completed'
+                }
+            }
+            Mock Add-AppxPackage { }
+
+            $result = Test-WingetSources
+            $result | Should -Be $true
+            Assert-MockCalled Add-AppxPackage -Times 1
+        }
+    }
+
+    Context 'When winget sources repair fails' {
+        It 'Should return false when Add-AppxPackage throws error' {
+            Mock winget {
+                if ($args[0] -eq 'source' -and $args[1] -eq 'list') {
+                    return 'msstore      https://storeedgefd.dsx.mp.microsoft.com/v9.0'
+                }
+                elseif ($args[0] -eq 'source' -and $args[1] -eq 'reset') {
+                    return 'Source reset completed'
+                }
+            }
             Mock Add-AppxPackage { throw 'Network error' }
 
             $result = Test-WingetSources
@@ -522,23 +574,66 @@ Describe 'Test-WingetSources' {
         }
     }
 
-    Context 'When winget sources are broken and still broken after repair' {
-        It 'Should return false and emit error messages' {
-            Mock winget { return 'msstore      https://storeedgefd.dsx.mp.microsoft.com/v9.0' } -ParameterFilter { $args[0] -eq 'source' -and $args[1] -eq 'list' -and $args -contains '--disable-interactivity' }
+    Context 'When winget source is corrupted and source reset fails' {
+        It 'Should still attempt Add-AppxPackage as fallback' {
+            $script:listCallCount = 0
+            $script:updateCallCount = 0
+            Mock winget {
+                if ($args[0] -eq 'source' -and $args[1] -eq 'list') {
+                    $script:listCallCount++
+                    if ($script:listCallCount -eq 1) {
+                        # Initially: source is listed
+                        return 'winget      https://cdn.winget.microsoft.com/cache'
+                    }
+                    # After repair attempt: still listed (but Add-AppxPackage will fix it)
+                    return 'winget      https://cdn.winget.microsoft.com/cache'
+                }
+                elseif ($args[0] -eq 'source' -and $args[1] -eq 'update') {
+                    $script:updateCallCount++
+                    if ($script:updateCallCount -eq 1) {
+                        # Initially: corrupted
+                        return '0x8a15000f Data required by the source is missing'
+                    }
+                    # After Add-AppxPackage: works
+                    return 'Operation completed successfully'
+                }
+                elseif ($args[0] -eq 'source' -and $args[1] -eq 'reset') {
+                    # Reset fails
+                    throw 'Access denied'
+                }
+            }
             Mock Add-AppxPackage { }
 
             $result = Test-WingetSources
-            $result | Should -Be $false
+            $result | Should -Be $true
+            Assert-MockCalled Add-AppxPackage -Times 1
         }
     }
 
     Context 'When winget source list throws an exception' {
         It 'Should attempt repair and handle the error gracefully' {
-            Mock winget { throw 'Access denied' } -ParameterFilter { $args[0] -eq 'source' -and $args[1] -eq 'list' -and $args -contains '--disable-interactivity' }
-            Mock Add-AppxPackage { throw 'Network error' }
+            $script:listCount = 0
+            Mock winget {
+                if ($args[0] -eq 'source' -and $args[1] -eq 'list') {
+                    $script:listCount++
+                    if ($script:listCount -eq 1) {
+                        throw 'Access denied'
+                    }
+                    # After repair, list succeeds
+                    return 'winget      https://cdn.winget.microsoft.com/cache'
+                }
+                elseif ($args[0] -eq 'source' -and $args[1] -eq 'update') {
+                    return 'Operation completed successfully'
+                }
+                elseif ($args[0] -eq 'source' -and $args[1] -eq 'reset') {
+                    return 'Source reset completed'
+                }
+            }
+            Mock Add-AppxPackage { }
 
             $result = Test-WingetSources
-            $result | Should -Be $false
+            $result | Should -Be $true
+            Assert-MockCalled Add-AppxPackage -Times 1
         }
     }
 }

--- a/Test-WingetAppInstall.Tests.ps1
+++ b/Test-WingetAppInstall.Tests.ps1
@@ -489,8 +489,8 @@ Describe 'Test-WingetSources' {
                 if ($args[0] -eq 'source' -and $args[1] -eq 'list') {
                     return 'winget      https://cdn.winget.microsoft.com/cache'
                 }
-                elseif ($args[0] -eq 'source' -and $args[1] -eq 'update') {
-                    return 'Operation completed successfully'
+                elseif ($args[0] -eq 'search' -and $args[1] -eq '7zip') {
+                    return '7zip.7zip    7.30'
                 }
             }
             Mock Add-AppxPackage { }
@@ -503,19 +503,21 @@ Describe 'Test-WingetSources' {
 
     Context 'When winget source is corrupted (0x8a15000f)' {
         It 'Should detect corruption and attempt repair with source reset' {
-            $script:updateCount = 0
+            $script:searchCount = 0
             Mock winget {
                 if ($args[0] -eq 'source' -and $args[1] -eq 'list') {
                     return 'winget      https://cdn.winget.microsoft.com/cache'
                 }
-                elseif ($args[0] -eq 'source' -and $args[1] -eq 'update') {
-                    $script:updateCount++
-                    if ($script:updateCount -eq 1) {
+                elseif ($args[0] -eq 'search' -and $args[1] -eq '7zip') {
+                    $script:searchCount++
+                    if ($script:searchCount -eq 1) {
                         # First call: corrupted data
-                        return 'Failed: 0x8a15000f Data required by the source is missing'
+                        $global:LASTEXITCODE = 1
+                        return 'Failed when opening source(s); try the source reset command if the problem persists. 0x8a15000f Data required by the source is missing'
                     }
                     # After reset: works
-                    return 'Operation completed successfully'
+                    $global:LASTEXITCODE = 0
+                    return '7zip.7zip    7.30'
                 }
                 elseif ($args[0] -eq 'source' -and $args[1] -eq 'reset') {
                     return 'Source reset completed'
@@ -532,6 +534,7 @@ Describe 'Test-WingetSources' {
     Context 'When winget sources are missing entirely' {
         It 'Should attempt repair with source reset and Add-AppxPackage' {
             $script:listCallCount = 0
+            $script:searchCallCount = 0
             Mock winget {
                 if ($args[0] -eq 'source' -and $args[1] -eq 'list') {
                     $script:listCallCount++
@@ -542,8 +545,13 @@ Describe 'Test-WingetSources' {
                     # After repair: winget source is restored
                     return 'winget      https://cdn.winget.microsoft.com/cache'
                 }
-                elseif ($args[0] -eq 'source' -and $args[1] -eq 'update') {
-                    return 'Operation completed successfully'
+                elseif ($args[0] -eq 'search' -and $args[1] -eq '7zip') {
+                    $script:searchCallCount++
+                    if ($script:searchCallCount -eq 2) {
+                        # After repair: search works
+                        $global:LASTEXITCODE = 0
+                        return '7zip.7zip    7.30'
+                    }
                 }
                 elseif ($args[0] -eq 'source' -and $args[1] -eq 'reset') {
                     return 'Source reset completed'
@@ -577,7 +585,7 @@ Describe 'Test-WingetSources' {
     Context 'When winget source is corrupted and source reset fails' {
         It 'Should still attempt Add-AppxPackage as fallback' {
             $script:listCallCount = 0
-            $script:updateCallCount = 0
+            $script:searchCallCount = 0
             Mock winget {
                 if ($args[0] -eq 'source' -and $args[1] -eq 'list') {
                     $script:listCallCount++
@@ -588,14 +596,16 @@ Describe 'Test-WingetSources' {
                     # After repair attempt: still listed (but Add-AppxPackage will fix it)
                     return 'winget      https://cdn.winget.microsoft.com/cache'
                 }
-                elseif ($args[0] -eq 'source' -and $args[1] -eq 'update') {
-                    $script:updateCallCount++
-                    if ($script:updateCallCount -eq 1) {
+                elseif ($args[0] -eq 'search' -and $args[1] -eq '7zip') {
+                    $script:searchCallCount++
+                    if ($script:searchCallCount -eq 1) {
                         # Initially: corrupted
+                        $global:LASTEXITCODE = 1
                         return '0x8a15000f Data required by the source is missing'
                     }
                     # After Add-AppxPackage: works
-                    return 'Operation completed successfully'
+                    $global:LASTEXITCODE = 0
+                    return '7zip.7zip    7.30'
                 }
                 elseif ($args[0] -eq 'source' -and $args[1] -eq 'reset') {
                     # Reset fails
@@ -613,6 +623,7 @@ Describe 'Test-WingetSources' {
     Context 'When winget source list throws an exception' {
         It 'Should attempt repair and handle the error gracefully' {
             $script:listCount = 0
+            $script:searchCount = 0
             Mock winget {
                 if ($args[0] -eq 'source' -and $args[1] -eq 'list') {
                     $script:listCount++
@@ -622,8 +633,13 @@ Describe 'Test-WingetSources' {
                     # After repair, list succeeds
                     return 'winget      https://cdn.winget.microsoft.com/cache'
                 }
-                elseif ($args[0] -eq 'source' -and $args[1] -eq 'update') {
-                    return 'Operation completed successfully'
+                elseif ($args[0] -eq 'search' -and $args[1] -eq '7zip') {
+                    $script:searchCount++
+                    if ($script:searchCount -eq 2) {
+                        # After repair: search works
+                        $global:LASTEXITCODE = 0
+                        return '7zip.7zip    7.30'
+                    }
                 }
                 elseif ($args[0] -eq 'source' -and $args[1] -eq 'reset') {
                     return 'Source reset completed'

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -826,14 +826,17 @@ function Test-WingetSources {
         $sourceIsListed = $false
     }
 
-    # Second check: verify source is functional (not corrupted)
+    # Second check: verify source is functional (not corrupted) by attempting a search
     $sourceIsFunctional = $false
     if ($sourceIsListed) {
         try {
-            $updateOutput = winget source update --disable-interactivity 2>&1
+            # Actually test if the source works by attempting a search
+            # Use '7zip' as a known package that always exists
+            $searchOutput = winget search 7zip --source winget --disable-interactivity 2>&1
+            $searchExitCode = $LASTEXITCODE
 
             # Check for corruption error code 0x8a15000f or similar source errors
-            if ($updateOutput -match '0x8a150|failed when opening|data required') {
+            if ($searchOutput -match '0x8a150|failed when opening|data required' -or $searchExitCode -ne 0) {
                 Write-WarningMessage 'Winget source is listed but contains corrupted or missing data.'
                 $sourceIsFunctional = $false
             }
@@ -843,7 +846,7 @@ function Test-WingetSources {
             }
         }
         catch {
-            Write-WarningMessage "Winget source update check failed: $_"
+            Write-WarningMessage "Winget source functionality test failed: $_"
             $sourceIsFunctional = $false
         }
     }
@@ -897,8 +900,10 @@ function Test-WingetSources {
     $sourceIsFunctional = $false
     if ($sourceIsListed) {
         try {
-            $updateOutput = winget source update --disable-interactivity 2>&1
-            $sourceIsFunctional = -not ($updateOutput -match '0x8a150|failed when opening|data required')
+            # Test source functionality with actual search
+            $searchOutput = winget search 7zip --source winget --disable-interactivity 2>&1
+            $searchExitCode = $LASTEXITCODE
+            $sourceIsFunctional = -not ($searchOutput -match '0x8a150|failed when opening|data required' -or $searchExitCode -ne 0)
         }
         catch {
             $sourceIsFunctional = $false

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -816,45 +816,104 @@ function Test-AndInstallWinget {
 function Test-WingetSources {
     Write-Info 'Checking winget sources...'
 
+    # First check: verify source is listed
     try {
         $output = winget source list --disable-interactivity 2>&1
-        if ($output -match 'winget') {
-            Write-Success 'Winget sources are accessible.'
-            return $true
-        }
+        $sourceIsListed = $output -match 'winget'
     }
     catch {
         Write-WarningMessage "Winget source list failed: $_"
+        $sourceIsListed = $false
     }
 
-    Write-WarningMessage 'Winget source "winget" appears to be broken or missing. Attempting to repair...'
+    # Second check: verify source is functional (not corrupted)
+    $sourceIsFunctional = $false
+    if ($sourceIsListed) {
+        try {
+            $updateOutput = winget source update --disable-interactivity 2>&1
+
+            # Check for corruption error code 0x8a15000f or similar source errors
+            if ($updateOutput -match '0x8a150|failed when opening|data required') {
+                Write-WarningMessage 'Winget source is listed but contains corrupted or missing data.'
+                $sourceIsFunctional = $false
+            }
+            else {
+                Write-Success 'Winget sources are accessible and functional.'
+                $sourceIsFunctional = $true
+            }
+        }
+        catch {
+            Write-WarningMessage "Winget source update check failed: $_"
+            $sourceIsFunctional = $false
+        }
+    }
+
+    # If both checks pass, sources are good
+    if ($sourceIsListed -and $sourceIsFunctional) {
+        return $true
+    }
+
+    # If source is missing entirely, attempt repair
+    if (-not $sourceIsListed) {
+        Write-WarningMessage 'Winget source "winget" appears to be missing. Attempting to repair...'
+    }
+    else {
+        Write-WarningMessage 'Winget source data is corrupted. Attempting to repair...'
+    }
+
+    # Attempt repair: first try source reset, then re-register package
+    try {
+        Write-Info 'Running winget source reset...'
+        $resetOutput = winget source reset --force --disable-interactivity 2>&1
+        Write-Info 'Source reset completed.'
+    }
+    catch {
+        Write-WarningMessage "Winget source reset failed: $_"
+    }
 
     try {
+        Write-Info 'Re-registering winget source package...'
         Add-AppxPackage -Path 'https://cdn.winget.microsoft.com/cache/source.msix' -ErrorAction Stop
         Write-Info 'Winget source package registered. Retrying source check...'
     }
     catch {
         Write-ErrorMessage "Failed to register winget source package: $_"
-        Write-ErrorMessage 'Manual remediation: Run the following as the local user (not as admin):'
-        Write-ErrorMessage '  Add-AppxPackage -Path "https://cdn.winget.microsoft.com/cache/source.msix"'
+        Write-ErrorMessage 'Manual remediation steps:'
+        Write-ErrorMessage '  1. Run as local user (not as admin): Add-AppxPackage -Path "https://cdn.winget.microsoft.com/cache/source.msix"'
+        Write-ErrorMessage '  2. Or run: winget source reset --force'
         return $false
     }
 
-    # Retry source check after repair
+    # Retry both checks after repair
     try {
         $output = winget source list --disable-interactivity 2>&1
-        if ($output -match 'winget') {
-            Write-Success 'Winget sources are now accessible.'
-            return $true
-        }
+        $sourceIsListed = $output -match 'winget'
     }
     catch {
         Write-WarningMessage "Winget source list failed after repair: $_"
+        $sourceIsListed = $false
+    }
+
+    $sourceIsFunctional = $false
+    if ($sourceIsListed) {
+        try {
+            $updateOutput = winget source update --disable-interactivity 2>&1
+            $sourceIsFunctional = -not ($updateOutput -match '0x8a150|failed when opening|data required')
+        }
+        catch {
+            $sourceIsFunctional = $false
+        }
+    }
+
+    if ($sourceIsListed -and $sourceIsFunctional) {
+        Write-Success 'Winget sources are now accessible and functional.'
+        return $true
     }
 
     Write-ErrorMessage 'Winget sources are still not accessible after repair attempt.'
-    Write-ErrorMessage 'Manual remediation: Run the following as the local user (not as admin):'
-    Write-ErrorMessage '  Add-AppxPackage -Path "https://cdn.winget.microsoft.com/cache/source.msix"'
+    Write-ErrorMessage 'Manual remediation steps:'
+    Write-ErrorMessage '  1. Run as local user (not as admin): Add-AppxPackage -Path "https://cdn.winget.microsoft.com/cache/source.msix"'
+    Write-ErrorMessage '  2. Or run: winget source reset --force'
     return $false
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes issue #77: Enhances `Test-WingetSources` to actually detect corrupted winget source data (error `0x8a15000f`).

**Key fix:** Changed validation from `winget source update` to `winget search 7zip --source winget`. The update command doesn't catch corruption—only actual usage does.

### Why are we doing this?

The previous implementation only checked if the "winget" source was *listed*, not if it was *functional*. When sources had corrupted index data (`0x8a15000f: Data required by the source is missing`), the validation incorrectly passed, and all subsequent app installations would fail.

### How should this be tested?

Test on a fresh system where winget sources have not been fully indexed:
```powershell
Set-ExecutionPolicy Unrestricted -Scope Process; irm "https://raw.githubusercontent.com/J-MaFf/winget-app-setup/fix/77-detect-corrupted-source-data/winget-app-install.ps1" | iex
```

Expected behavior:
- Detects corrupted source automatically
- Runs `winget source reset --force` to clear cache
- Falls back to `Add-AppxPackage` re-registration if needed
- Retries validation after repair
- Applications install successfully

### Test Results

All 125 Pester tests passing:
- 6 Test-WingetSources contexts covering all corruption scenarios
- 2-stage validation with functional test (search) instead of metadata check
- Exception handling for list, reset, and search operations

Closes #77