### PR TITLE
Add error handling to Save-UpdateConfiguration

### DIFF
--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -861,7 +861,12 @@ function Save-UpdateConfiguration {
         New-Item -Path $paths.BasePath -ItemType Directory -Force | Out-Null
     }
 
-    $Configuration | ConvertTo-Json | Set-Content -Path $paths.ConfigFile -Encoding UTF8
+    try {
+        $Configuration | ConvertTo-Json | Set-Content -Path $paths.ConfigFile -Encoding UTF8 -ErrorAction Stop
+    }
+    catch {
+        Write-WarningMessage "Failed to save update configuration: $_"
+    }
 }
 
 <#


### PR DESCRIPTION
## Summary
- Wrap `Set-Content` in a try/catch in `Save-UpdateConfiguration`
- Previously a full or locked `%APPDATA%` would silently drop the config write, causing the user to be re-prompted on the next run as if no config existed

Fixes #86

## Test plan
- [ ] Normal run — config saves as expected
- [ ] Simulate inaccessible path — warning is shown, script continues without crashing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)