### PR TITLE
Capture LASTEXITCODE immediately after winget upgrade call

### DIFF
--- a/Update-InstalledApps.ps1
+++ b/Update-InstalledApps.ps1
@@ -193,13 +193,14 @@ if ($autoInstall) {
     foreach ($update in $updates) {
         try {
             $upgradeOutput = & winget upgrade -e --id $update.PackageName --accept-source-agreements --accept-package-agreements --disable-interactivity 2>&1
-            if ($LASTEXITCODE -eq 0) {
+            $wingetExitCode = $LASTEXITCODE
+            if ($wingetExitCode -eq 0) {
                 $successfulUpdates += $update
                 Write-UpdateLog "SUCCESS | $($update.PackageName) | $($update.CurrentVersion) -> $($update.AvailableVersion)"
             }
             else {
                 $failedUpdates += $update
-                Write-UpdateLog "FAILED  | $($update.PackageName) | $($update.CurrentVersion) -> $($update.AvailableVersion) | Output: $($upgradeOutput | Out-String)"
+                Write-UpdateLog "FAILED  | $($update.PackageName) | $($update.CurrentVersion) -> $($update.AvailableVersion) | ExitCode: $wingetExitCode | Output: $($upgradeOutput | Out-String)"
             }
         }
         catch {


### PR DESCRIPTION
## Summary
- Assign `$LASTEXITCODE` to a local variable on the line immediately after `& winget upgrade` in `Update-InstalledApps.ps1`
- In PowerShell 7+, `$LASTEXITCODE` can be stale by the time it's read if any other code runs between the native call and the check
- Also includes the exit code in failure log lines for easier debugging

Fixes #87

## Test plan
- [ ] Successful upgrade — logged as SUCCESS
- [ ] Failed upgrade (e.g. package not found) — logged as FAILED with exit code

🤖 Generated with [Claude Code](https://claude.ai/claude-code)