### PR TITLE
Add bounds check before Split index access in Invoke-WingetCommand

### DIFF
--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -678,10 +678,16 @@ function Invoke-WingetCommand {
 
     $commandOutput | ForEach-Object {
         if ($_ -match $SuccessPattern) {
-            $SuccessArray.Value += $_.Split()[$SuccessIndex]
+            $parts = $_.Split()
+            if ($SuccessIndex -lt $parts.Count) {
+                $SuccessArray.Value += $parts[$SuccessIndex]
+            }
         }
         elseif ($_ -match $FailurePattern) {
-            $FailureArray.Value += $_.Split()[$FailureIndex]
+            $parts = $_.Split()
+            if ($FailureIndex -lt $parts.Count) {
+                $FailureArray.Value += $parts[$FailureIndex]
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Guard `$_.Split()[$SuccessIndex]` and `$_.Split()[$FailureIndex]` with a bounds check before access
- Without this, a matched line with fewer tokens than the expected index silently adds `$null` to the result arrays, corrupting the install summary

Fixes #93

## Test plan
- [ ] Normal install output — success/failure arrays populated correctly
- [ ] Short/malformed output line matching a pattern — entry skipped, no `$null` in arrays

🤖 Generated with [Claude Code](https://claude.ai/claude-code)