### PR TITLE
Validate package ID format in Get-UpdateReport CLI parsing

### DIFF
--- a/Update-InstalledApps.ps1
+++ b/Update-InstalledApps.ps1
@@ -94,7 +94,7 @@ function Get-UpdateReport {
         if ($line -match '^\s*-{3,}') { continue }
         if ($line -match 'No installed package found|No available upgrade found|No newer package versions are available') { continue }
         $columns = $line.Trim() -split '\s{2,}'
-        if ($columns.Count -ge 4) {
+        if ($columns.Count -ge 4 -and $columns[1] -match '^[\w][\w.\-]+\.[\w][\w.\-]+$') {
             $report += [PSCustomObject]@{
                 PackageName      = $columns[1]
                 CurrentVersion   = $columns[2]

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -901,7 +901,7 @@ function Get-UpdateReport {
             if ($line -match 'No installed package found|No available upgrade found|No newer package versions are available') { continue }
 
             $columns = $line.Trim() -split '\s{2,}'
-            if ($columns.Count -ge 4) {
+            if ($columns.Count -ge 4 -and $columns[1] -match '^[\w][\w.\-]+\.[\w][\w.\-]+$') {
                 $report += [PSCustomObject]@{
                     PackageName      = $columns[1]
                     CurrentVersion   = $columns[2]


### PR DESCRIPTION
## Summary
- Add a regex check that `$columns[1]` matches `Publisher.Name` format before accepting a parsed row
- Winget output with long package names can cause column misalignment, previously producing records with wrong names or versions silently
- Applied to both `winget-app-install.ps1` and `Update-InstalledApps.ps1`

Fixes #94

## Test plan
- [ ] Normal winget upgrade output — records parsed correctly
- [ ] Long package name causing column wrap — misaligned row skipped

🤖 Generated with [Claude Code](https://claude.ai/claude-code)