### PR TITLE
fix: add --accept-source-agreements to all winget source commands

### DIFF
--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -212,7 +212,7 @@ function Test-AppDefinitions {
 #>
 function Test-Source-IsTrusted($target) {
     try {
-        $sources = winget source list --disable-interactivity 2>&1
+        $sources = winget source list --disable-interactivity --accept-source-agreements 2>&1
         return $sources -match [regex]::Escape($target)
     }
     catch {
@@ -236,7 +236,7 @@ function Set-Sources {
         # Run winget source reset with a timeout to prevent hanging
         # Using Start-Process with a timeout to handle potential hangs
         $resetProcess = Start-Process -FilePath 'winget' `
-            -ArgumentList 'source', 'reset', '--force', '--disable-interactivity' `
+            -ArgumentList 'source', 'reset', '--force', '--disable-interactivity', '--accept-source-agreements' `
             -NoNewWindow `
             -PassThru `
             -RedirectStandardOutput "$env:TEMP\winget_reset_output.txt" `
@@ -1122,7 +1122,7 @@ function Test-WingetSources {
 
     # First check: verify source is listed
     try {
-        $output = winget source list --disable-interactivity 2>&1
+        $output = winget source list --disable-interactivity --accept-source-agreements 2>&1
         $sourceIsListed = $output -match 'winget'
     }
     catch {
@@ -1171,7 +1171,7 @@ function Test-WingetSources {
     # Attempt repair: first try source reset, then re-register package
     try {
         Write-Info 'Running winget source reset...'
-        $resetOutput = winget source reset --force --disable-interactivity 2>&1
+        $resetOutput = winget source reset --force --disable-interactivity --accept-source-agreements 2>&1
         Write-Info 'Source reset completed.'
     }
     catch {
@@ -1193,7 +1193,7 @@ function Test-WingetSources {
 
     # Retry both checks after repair
     try {
-        $output = winget source list --disable-interactivity 2>&1
+        $output = winget source list --disable-interactivity --accept-source-agreements 2>&1
         $sourceIsListed = $output -match 'winget'
     }
     catch {

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -1781,8 +1781,23 @@ function Invoke-WingetInstall {
     # Determine which PowerShell executable to use
     $psExecutable = if (Get-Command pwsh -ErrorAction SilentlyContinue) { 'pwsh.exe' } else { 'powershell.exe' }
 
+    # Accept msstore source agreements in the user context before elevating.
+    # Agreements are per-user — they won't carry over into the elevated process.
+    # Running winget source update here surfaces the interactive prompt while we
+    # still have the normal user's identity.
+    $isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')
+    if (-not $isAdmin -and Test-IsRunningLocally) {
+        if ($WhatIf) {
+            Write-Info '[DRY-RUN] Would run winget source update to prompt for source agreement acceptance in user context'
+        }
+        else {
+            Write-Info 'Updating winget sources — accept any prompts that appear to continue...'
+            Start-Process -FilePath 'winget' -ArgumentList 'source', 'update' -Wait -NoNewWindow
+        }
+    }
+
     # Check if the script is run as administrator
-    If (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')) {
+    If (-NOT $isAdmin) {
         if (Test-IsRunningLocally) {
             Write-ErrorMessage 'This script requires administrator privileges. Press Enter to restart script with elevated privileges.'
             Pause

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -1786,7 +1786,7 @@ function Invoke-WingetInstall {
     # Running winget source update here surfaces the interactive prompt while we
     # still have the normal user's identity.
     $isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')
-    if (-not $isAdmin -and Test-IsRunningLocally) {
+    if (-not $isAdmin -and (Test-IsRunningLocally)) {
         if ($WhatIf) {
             Write-Info '[DRY-RUN] Would run winget source update to prompt for source agreement acceptance in user context'
         }


### PR DESCRIPTION
Fixes #107

## Problem

`--accept-source-agreements` was passed on individual `winget install`/`upgrade` calls, but not on `winget source list` or `winget source reset`. Passing the flag per-command suppresses the prompt for that invocation but does not persist agreement acceptance to the user's winget profile. Any subsequent out-of-script `winget` invocation — manual `winget update --all`, scheduled tasks running as the user — still hits the interactive `msstore` agreement prompt.

## Changes

Added `--accept-source-agreements` to every `winget source list` and `winget source reset` call:

| Location | Command |
|---|---|
| `Test-Source-IsTrusted` | `winget source list` |
| `Set-Sources` | `winget source reset` (via `Start-Process`) |
| `Test-WingetSources` | `winget source list` (initial check) |
| `Test-WingetSources` | `winget source reset` (repair path) |
| `Test-WingetSources` | `winget source list` (post-repair recheck) |

## Testing

Existing Pester tests mock `winget` by subcommand (`$args[0]`/`$args[1]`) and are unaffected by the additional flag. Manual verification: run install script on a fresh user profile, then open a new session and confirm `winget update --all --include-unknown` no longer prompts for source agreements.