### PR TITLE
fix: scheduled-task test mocks + module-extraction test cleanup (#111)

### DIFF
--- a/Test-WingetAppInstall.Tests.ps1
+++ b/Test-WingetAppInstall.Tests.ps1
@@ -1783,10 +1783,19 @@ Describe 'Scheduled Updates - Unit Tests' -Tag 'ScheduledUpdates' {
         Mock Get-WinGetPackage { }
         Mock winget { }
         Mock Get-ScheduledTask { $null }
-        Mock New-ScheduledTaskAction { @{ Action = 'ok' } }
-        Mock New-ScheduledTaskTrigger { @{ Trigger = 'ok' } }
-        Mock New-ScheduledTaskSettingsSet { @{ Settings = 'ok' } }
-        Mock New-ScheduledTaskPrincipal { @{ Principal = 'ok' } }
+        # On Windows Register-ScheduledTask is a real cmdlet whose -Action/-Trigger/-Settings/
+        # -Principal parameters require [CimInstance] arguments tagged with a specific PSTypeName
+        # (e.g. Microsoft.Management.Infrastructure.CimInstance#MSFT_TaskSettings). Returning plain
+        # hashtables from these mocks fails argument binding *before* the Register mock body runs,
+        # so Enable-ScheduledUpdatesCheck's try/catch swallows it and returns $false (issue #111).
+        # Pester's -RemoveParameterType can't help here: it strips the static type but leaves the
+        # CDXML argument-transformation / PSTypeName attributes. Returning bare client-side
+        # CimInstances with the matching class names satisfies binding on Windows, and is harmless
+        # on Linux where these cmdlets don't exist (the mocks become plain typeless functions).
+        Mock New-ScheduledTaskAction { [Microsoft.Management.Infrastructure.CimInstance]::new('MSFT_TaskAction') }
+        Mock New-ScheduledTaskTrigger { [Microsoft.Management.Infrastructure.CimInstance]::new('MSFT_TaskTrigger') }
+        Mock New-ScheduledTaskSettingsSet { [Microsoft.Management.Infrastructure.CimInstance]::new('MSFT_TaskSettings') }
+        Mock New-ScheduledTaskPrincipal { [Microsoft.Management.Infrastructure.CimInstance]::new('MSFT_TaskPrincipal') }
         Mock Register-ScheduledTask { }
         Mock Unregister-ScheduledTask { }
         Mock Write-Info { }


### PR DESCRIPTION
## Summary

Fixes a Windows-only failure in the Pester suite (issue #111): `Enable-ScheduledUpdatesCheck should create task and persist config`.

## Root cause

On Windows, `Register-ScheduledTask`'s `-Action`/`-Trigger`/`-Settings`/`-Principal` parameters require `[CimInstance]` arguments tagged with a specific `PSTypeName` (e.g. `Microsoft.Management.Infrastructure.CimInstance#MSFT_TaskSettings`). The `New-ScheduledTask*` test mocks returned plain hashtables, so argument binding failed *before* the mock body ran, and `Enable-ScheduledUpdatesCheck`'s try/catch returned `$false`. The production code is correct — this was a test-double typing issue.

Pester's `-RemoveParameterType` does not resolve it: it strips the static type but leaves the CDXML argument-transformation / `PSTypeName` attributes. The mocks now return bare client-side `CimInstance` objects with the matching class names, which satisfy binding on Windows and stay harmless on Linux where the cmdlets do not exist (the mocks become plain typeless functions there).

## Testing

Run locally on Windows 11 (PowerShell 7, Pester 5.7.1):

```
Invoke-Pester ./Test-WingetAppInstall.Tests.ps1
```

Reported 123 passed / 0 failed / 1 skipped. The Linux leg was not run from this machine.

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
