### PR TITLE
build: make installer -Check line-ending deterministic across platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Keep PowerShell sources and the generated installer LF-normalized on every platform.
+# Without this, core.autocrlf=true rewrites the trailing newline to CRLF on Windows
+# checkouts, which makes build/Build-WingetInstallScript.ps1 -Check report a false
+# "out of date" even when the installer is in sync with the WingetAppSetup module.
+*.ps1  text eol=lf
+*.psm1 text eol=lf
+*.psd1 text eol=lf

--- a/build/Build-WingetInstallScript.ps1
+++ b/build/Build-WingetInstallScript.ps1
@@ -75,15 +75,21 @@ foreach ($file in $functionFiles) {
 [void]$builder.AppendLine('')
 [void]$builder.AppendLine((Get-Content -Path (Join-Path $fragmentsRoot 'tail.ps1') -Raw).TrimEnd())
 
-# Normalize to a single trailing newline
-$content = $builder.ToString().TrimEnd() + "`n"
+# Normalize to LF line endings with a single trailing newline so the output is
+# byte-identical across platforms. StringBuilder.AppendLine emits [Environment]::NewLine
+# (CRLF on Windows, LF on Linux), and the source files may be checked out with CRLF under
+# core.autocrlf, so collapse everything to LF here. The installer is stored with LF (see
+# .gitattributes), keeping the -Check round-trip deterministic on Windows and Linux alike.
+$content = (($builder.ToString() -replace "`r`n", "`n").TrimEnd()) + "`n"
 
 if ($Check) {
     if (-not (Test-Path $OutputPath)) {
         Write-Error "Check failed: '$OutputPath' does not exist. Run the build to generate it."
         exit 1
     }
-    $current = (Get-Content -Path $OutputPath -Raw)
+    # Normalize the on-disk copy to LF before comparing; a Windows checkout with
+    # core.autocrlf=true can present the file with CRLF even when it is in sync.
+    $current = ((Get-Content -Path $OutputPath -Raw) -replace "`r`n", "`n")
     if ($current -ne $content) {
         Write-Error "Check failed: '$OutputPath' is out of date. Re-run build/Build-WingetInstallScript.ps1."
         exit 1


### PR DESCRIPTION
## Problem

`build/Build-WingetInstallScript.ps1 -Check` reports the generated `winget-app-install.ps1` as **out of date** on Windows checkouts even when it is fully in sync with the `WingetAppSetup` module — blocking the gate that's supposed to prove the installer was regenerated and not hand-edited.

### Root cause
- `StringBuilder.AppendLine` emits `[Environment]::NewLine` — **CRLF on Windows, LF on Linux** (where the file was last built/committed).
- The final newline was a hard-coded LF (`+ "\`n"`).
- The repo had no `.gitattributes`, so with `core.autocrlf=true` the committed file's trailing LF is rewritten to CRLF on checkout.
- `-Check`'s raw string comparison then sees a 1-byte difference and fails.

Verified during #106 validation: after normalizing CRLF→LF, a fresh build and the committed installer are **byte-for-byte identical** (only the trailing terminator differed).

## Fix (belt-and-suspenders)
1. **Deterministic generation** — normalize the assembled output to LF before writing, so the build is byte-identical on Windows and Linux.
2. **Tolerant `-Check`** — normalize the on-disk copy to LF before comparing, so a CRLF working-tree checkout still matches when content is in sync.
3. **`.gitattributes`** — pin `*.ps1` / `*.psm1` / `*.psd1` to `eol=lf` so checkout never rewrites endings in the first place.

The generated `winget-app-install.ps1` is unchanged in content (it was already LF in the repo), so it is not part of this diff.

## Verification (Windows, pwsh 7.6.2)
- Regenerate + `-Check` round-trip: **passes** (exit 0).
- `-Check` against a **forced-CRLF** copy of the installer: **passes** (exit 0) — the original failure mode is handled.
- PSScriptAnalyzer on the build script: only the 2 pre-existing `Write-Host` warnings; no new findings.
- Linux: `AppendLine`→LF and the `-replace` is a no-op, so output and comparison stay LF — round-trip passes there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)