### PR TITLE
fix: never let -WhatIf elevate into a real install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed (Unreleased)
 
+- Fixed `-WhatIf` (dry-run) silently performing a real install: when run non-elevated, the script relaunched itself elevated but dropped the `-WhatIf` flag, so the admin session installed the full app list. A dry run now never elevates, and `Restart-WithElevation` forwards `-WhatIf` as a safety net ([#117](https://github.com/J-MaFf/winget-app-setup/issues/117)).
 - Corrected the CLAUDE.md winget note that referenced a non-existent `Invoke-WingetInstallWithSessionRetry`; it now describes the actual `0x80073d19` mitigation (user-context source init plus the single failed-install retry pass) ([#111](https://github.com/J-MaFf/winget-app-setup/issues/111)).
 - Cleaned up `Test-WingetAppInstall.Tests.ps1` so it no longer defines unused variables and satisfies the linter.
 - Fixed broken winget source scenario: when running as admin on a standard user account the "winget" source registration may be missing or broken; the script now detects and auto-repairs this condition instead of silently failing (#66).

--- a/STATUS.md
+++ b/STATUS.md
@@ -8,11 +8,15 @@ updates. End users run a single self-contained `winget-app-install.ps1`, either 
 remote `irm | iex` one-liner. Internally, the installer's logic now lives in the reusable
 `WingetAppSetup` module, and the single-file script is generated from it by a build step.
 
-## Current State — 2026-06-14
+## Current State — 2026-06-15
 
-`main` is clean. The install logic has been refactored from a 2,100-line monolith into a module
-([#106](https://github.com/J-MaFf/winget-app-setup/issues/106)); the distributable script is a
-generated build artifact that remains byte-for-byte behaviour-equivalent to the previous monolith.
+The module refactor ([#106](https://github.com/J-MaFf/winget-app-setup/issues/106)) is staged on
+`fix/106-module-refactor` (PR [#109](https://github.com/J-MaFf/winget-app-setup/pull/109), open,
+not yet merged to `main`); the distributable script is a generated build artifact that remains
+behaviour-equivalent to the previous monolith. Stacked onto that branch: the scheduled-task test
+fix (#111, merged), the LF-determinism build fix (merged), and a `-WhatIf` safety fix
+([#117](https://github.com/J-MaFf/winget-app-setup/issues/117), PR
+[#116](https://github.com/J-MaFf/winget-app-setup/pull/116), open).
 
 ### Components
 
@@ -35,6 +39,7 @@ generated build artifact that remains byte-for-byte behaviour-equivalent to the 
 | [#106](https://github.com/J-MaFf/winget-app-setup/issues/106) | Split `winget-app-install.ps1` into a module with a generated bundle | [#109](https://github.com/J-MaFf/winget-app-setup/pull/109) |
 | [#110](https://github.com/J-MaFf/winget-app-setup/issues/110) | Migrate uninstall + update-helper scripts to consume the module | _merged into #109_ |
 | [#111](https://github.com/J-MaFf/winget-app-setup/issues/111) | Remove orphaned tests for functions that no longer exist | _stacked on #109_ |
+| [#117](https://github.com/J-MaFf/winget-app-setup/issues/117) | `-WhatIf` dropped the flag on elevation and ran a real install | [#116](https://github.com/J-MaFf/winget-app-setup/pull/116) |
 
 ### Open Issues
 

--- a/Test-WingetAppInstall.Tests.ps1
+++ b/Test-WingetAppInstall.Tests.ps1
@@ -637,6 +637,28 @@ Describe 'Restart-WithElevation' {
         Assert-MockCalled Start-Process -ParameterFilter { $FilePath -eq 'pwsh.exe' } -Times 1
         $result | Should -Be 'PowerShell'
     }
+
+    It 'Should forward AdditionalArguments to the elevated relaunch' {
+        Mock Get-Command { return $null } -ParameterFilter { $Name -eq 'wt.exe' }
+        Mock Start-Process { } -ParameterFilter { $FilePath -eq 'pwsh.exe' }
+
+        Restart-WithElevation -PowerShellExecutable 'pwsh.exe' -ScriptPath 'C:\script.ps1' -AdditionalArguments '-WhatIf'
+
+        Assert-MockCalled Start-Process -Times 1 -ParameterFilter {
+            $FilePath -eq 'pwsh.exe' -and (($ArgumentList -join ' ') -match '-File "C:\\script\.ps1" -WhatIf')
+        }
+    }
+
+    It 'Should not append arguments when AdditionalArguments is empty' {
+        Mock Get-Command { return $null } -ParameterFilter { $Name -eq 'wt.exe' }
+        Mock Start-Process { } -ParameterFilter { $FilePath -eq 'pwsh.exe' }
+
+        Restart-WithElevation -PowerShellExecutable 'pwsh.exe' -ScriptPath 'C:\script.ps1'
+
+        Assert-MockCalled Start-Process -Times 1 -ParameterFilter {
+            $FilePath -eq 'pwsh.exe' -and (($ArgumentList -join ' ') -notmatch '-WhatIf')
+        }
+    }
 }
 
 Describe 'Test-CanUseGridView' {

--- a/WingetAppSetup/Private/Elevation.ps1
+++ b/WingetAppSetup/Private/Elevation.ps1
@@ -38,6 +38,9 @@ function Test-IsRunningLocally {
 .PARAMETER WindowsTerminalExecutable
     Optional explicit path to the Windows Terminal executable (wt.exe). When not supplied, the
     function attempts to discover it automatically.
+.PARAMETER AdditionalArguments
+    Optional switches/arguments to forward to the elevated relaunch (for example, '-WhatIf'). These
+    are appended after the -File argument so the elevated session inherits the caller's intent.
 .RETURNS
     [string] Returns 'WindowsTerminal' when the Windows Terminal relaunch path succeeds, otherwise
     returns 'PowerShell'.
@@ -51,11 +54,17 @@ function Restart-WithElevation {
         [string]$ScriptPath,
 
         [Parameter(Mandatory = $false)]
-        [string]$WindowsTerminalExecutable
+        [string]$WindowsTerminalExecutable,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$AdditionalArguments = @()
     )
 
     $quotedScriptPath = '"' + $ScriptPath.Replace('"', '`"') + '"'
     $commandArguments = "-NoProfile -ExecutionPolicy Bypass -File $quotedScriptPath"
+    if ($AdditionalArguments.Count -gt 0) {
+        $commandArguments += ' ' + ($AdditionalArguments -join ' ')
+    }
     $windowsTerminalPath = $WindowsTerminalExecutable
 
     if (-not $windowsTerminalPath) {

--- a/WingetAppSetup/Public/Install.ps1
+++ b/WingetAppSetup/Public/Install.ps1
@@ -39,20 +39,32 @@ function Invoke-WingetInstall {
     # Check if the script is run as administrator
     If (-NOT $isAdmin) {
         if (Test-IsRunningLocally) {
-            Write-ErrorMessage 'This script requires administrator privileges. Press Enter to restart script with elevated privileges.'
-            Pause
-            # Relaunch the script with administrator privileges
-            Restart-WithElevation -PowerShellExecutable $psExecutable -ScriptPath $PSCommandPath | Out-Null
-            Exit
+            # A dry run makes no system changes, so it never needs elevation. Relaunching
+            # elevated here would (a) be a surprising side effect for a preview and (b) — if
+            # the flag were ever dropped across the elevation boundary — silently turn a
+            # dry run into a real install. Stay in the current session and continue the preview.
+            if ($WhatIf) {
+                Write-Info '[DRY-RUN] Would relaunch with administrator privileges. Continuing the preview in the current (non-elevated) session; no system changes will be made.'
+            }
+            else {
+                Write-ErrorMessage 'This script requires administrator privileges. Press Enter to restart script with elevated privileges.'
+                Pause
+                # Relaunch the script with administrator privileges, forwarding -WhatIf as a
+                # safety net so the elevated session can never escalate a dry run into changes.
+                $elevationArgs = if ($WhatIf) { @('-WhatIf') } else { @() }
+                Restart-WithElevation -PowerShellExecutable $psExecutable -ScriptPath $PSCommandPath -AdditionalArguments $elevationArgs | Out-Null
+                Exit
+            }
         }
-
-        # IEX/remote execution has no local script path to relaunch from.
-        Write-ErrorMessage 'This script requires administrator privileges.'
-        Write-ErrorMessage 'Auto-elevation is unavailable when running through IEX/remote execution.'
-        Write-Info 'Open an elevated PowerShell or Windows Terminal session and run the IEX command again.'
-        Write-Info 'Exiting in 5 seconds...'
-        Start-Sleep -Seconds 5
-        Exit 1
+        else {
+            # IEX/remote execution has no local script path to relaunch from.
+            Write-ErrorMessage 'This script requires administrator privileges.'
+            Write-ErrorMessage 'Auto-elevation is unavailable when running through IEX/remote execution.'
+            Write-Info 'Open an elevated PowerShell or Windows Terminal session and run the IEX command again.'
+            Write-Info 'Exiting in 5 seconds...'
+            Start-Sleep -Seconds 5
+            Exit 1
+        }
     }
     else {
         Write-Success 'Starting...'

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -105,6 +105,9 @@ function Test-IsRunningLocally {
 .PARAMETER WindowsTerminalExecutable
     Optional explicit path to the Windows Terminal executable (wt.exe). When not supplied, the
     function attempts to discover it automatically.
+.PARAMETER AdditionalArguments
+    Optional switches/arguments to forward to the elevated relaunch (for example, '-WhatIf'). These
+    are appended after the -File argument so the elevated session inherits the caller's intent.
 .RETURNS
     [string] Returns 'WindowsTerminal' when the Windows Terminal relaunch path succeeds, otherwise
     returns 'PowerShell'.
@@ -118,11 +121,17 @@ function Restart-WithElevation {
         [string]$ScriptPath,
 
         [Parameter(Mandatory = $false)]
-        [string]$WindowsTerminalExecutable
+        [string]$WindowsTerminalExecutable,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$AdditionalArguments = @()
     )
 
     $quotedScriptPath = '"' + $ScriptPath.Replace('"', '`"') + '"'
     $commandArguments = "-NoProfile -ExecutionPolicy Bypass -File $quotedScriptPath"
+    if ($AdditionalArguments.Count -gt 0) {
+        $commandArguments += ' ' + ($AdditionalArguments -join ' ')
+    }
     $windowsTerminalPath = $WindowsTerminalExecutable
 
     if (-not $windowsTerminalPath) {
@@ -452,20 +461,32 @@ function Invoke-WingetInstall {
     # Check if the script is run as administrator
     If (-NOT $isAdmin) {
         if (Test-IsRunningLocally) {
-            Write-ErrorMessage 'This script requires administrator privileges. Press Enter to restart script with elevated privileges.'
-            Pause
-            # Relaunch the script with administrator privileges
-            Restart-WithElevation -PowerShellExecutable $psExecutable -ScriptPath $PSCommandPath | Out-Null
-            Exit
+            # A dry run makes no system changes, so it never needs elevation. Relaunching
+            # elevated here would (a) be a surprising side effect for a preview and (b) — if
+            # the flag were ever dropped across the elevation boundary — silently turn a
+            # dry run into a real install. Stay in the current session and continue the preview.
+            if ($WhatIf) {
+                Write-Info '[DRY-RUN] Would relaunch with administrator privileges. Continuing the preview in the current (non-elevated) session; no system changes will be made.'
+            }
+            else {
+                Write-ErrorMessage 'This script requires administrator privileges. Press Enter to restart script with elevated privileges.'
+                Pause
+                # Relaunch the script with administrator privileges, forwarding -WhatIf as a
+                # safety net so the elevated session can never escalate a dry run into changes.
+                $elevationArgs = if ($WhatIf) { @('-WhatIf') } else { @() }
+                Restart-WithElevation -PowerShellExecutable $psExecutable -ScriptPath $PSCommandPath -AdditionalArguments $elevationArgs | Out-Null
+                Exit
+            }
         }
-
-        # IEX/remote execution has no local script path to relaunch from.
-        Write-ErrorMessage 'This script requires administrator privileges.'
-        Write-ErrorMessage 'Auto-elevation is unavailable when running through IEX/remote execution.'
-        Write-Info 'Open an elevated PowerShell or Windows Terminal session and run the IEX command again.'
-        Write-Info 'Exiting in 5 seconds...'
-        Start-Sleep -Seconds 5
-        Exit 1
+        else {
+            # IEX/remote execution has no local script path to relaunch from.
+            Write-ErrorMessage 'This script requires administrator privileges.'
+            Write-ErrorMessage 'Auto-elevation is unavailable when running through IEX/remote execution.'
+            Write-Info 'Open an elevated PowerShell or Windows Terminal session and run the IEX command again.'
+            Write-Info 'Exiting in 5 seconds...'
+            Start-Sleep -Seconds 5
+            Exit 1
+        }
     }
     else {
         Write-Success 'Starting...'


### PR DESCRIPTION
Fixes #117

## Summary

Fixes a dangerous bug where `winget-app-install.ps1 -WhatIf` could perform a **real install** instead of a dry run. Discovered while testing the module-refactor branch. Targets `fix/106-module-refactor` so the fix is in place before #109 lands on `main`.

## The bug

Running the installer with `-WhatIf` as a non-admin user:

1. Prints the DRY-RUN banner.
2. Hits the not-admin check and relaunches elevated via `Restart-WithElevation`.
3. The relaunch command was built as `-NoProfile -ExecutionPolicy Bypass -File <script>` with **no arguments forwarded**, so the elevated session ran **without** `-WhatIf` and started a real install.

`-WhatIf` was silently dropped across the elevation boundary. Pre-existing defect — the monolithic installer on `main` has the same `-File <script>` relaunch with no flag forwarding; the refactor faithfully preserved it.

## Fix

Both changes live in the `WingetAppSetup` module (source of truth); `winget-app-install.ps1` is regenerated.

- **`Invoke-WingetInstall`** — in `-WhatIf` mode, do not elevate at all. A dry run makes no system changes, so it stays in the current non-elevated session and continues the preview instead of spawning an admin window.
- **`Restart-WithElevation`** — add `-AdditionalArguments` and forward `-WhatIf` through it as a safety net, so any elevation path keeps the dry-run intent.

## Testing (Windows 11, PowerShell 7, Pester 5.7.1)

- `Invoke-Pester ./Test-WingetAppInstall.Tests.ps1` -> 125 passed / 0 failed / 1 skipped (added 2 tests covering argument forwarding).
- `./build/Build-WingetInstallScript.ps1 -Check` -> passes (installer regenerated and in sync).

Docs: CHANGELOG.md and STATUS.md updated.