### PR TITLE
fix: guard post-install updates with a per-package timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed (Unreleased)
 
+- Fixed the post-install update phase hanging indefinitely on a stalled package upgrade. Each upgrade now runs through a timeout-guarded helper (`Invoke-WingetPackageUpgrade`) that kills a non-responsive `winget upgrade` and continues with the remaining packages, instead of piping every outdated package into a single unbounded `Update-WinGetPackage` call ([#120](https://github.com/J-MaFf/winget-app-setup/issues/120)).
 - Fixed `-WhatIf` (dry-run) silently performing a real install: when run non-elevated, the script relaunched itself elevated but dropped the `-WhatIf` flag, so the admin session installed the full app list. A dry run now never elevates, and `Restart-WithElevation` forwards `-WhatIf` as a safety net ([#117](https://github.com/J-MaFf/winget-app-setup/issues/117)).
 - Corrected the CLAUDE.md winget note that referenced a non-existent `Invoke-WingetInstallWithSessionRetry`; it now describes the actual `0x80073d19` mitigation (user-context source init plus the single failed-install retry pass) ([#111](https://github.com/J-MaFf/winget-app-setup/issues/111)).
 - Cleaned up `Test-WingetAppInstall.Tests.ps1` so it no longer defines unused variables and satisfies the linter.

--- a/STATUS.md
+++ b/STATUS.md
@@ -40,6 +40,7 @@ fix (#111, merged), the LF-determinism build fix (merged), and a `-WhatIf` safet
 | [#110](https://github.com/J-MaFf/winget-app-setup/issues/110) | Migrate uninstall + update-helper scripts to consume the module | _merged into #109_ |
 | [#111](https://github.com/J-MaFf/winget-app-setup/issues/111) | Remove orphaned tests for functions that no longer exist | _stacked on #109_ |
 | [#117](https://github.com/J-MaFf/winget-app-setup/issues/117) | `-WhatIf` dropped the flag on elevation and ran a real install | [#116](https://github.com/J-MaFf/winget-app-setup/pull/116) |
+| [#120](https://github.com/J-MaFf/winget-app-setup/issues/120) | Post-install update phase could hang indefinitely on one package | _PR open_ |
 
 ### Open Issues
 

--- a/Test-WingetAppInstall.Tests.ps1
+++ b/Test-WingetAppInstall.Tests.ps1
@@ -661,6 +661,70 @@ Describe 'Restart-WithElevation' {
     }
 }
 
+Describe 'Invoke-WingetPackageUpgrade' {
+    BeforeEach {
+        Mock Write-Success { }
+        Mock Write-WarningMessage { }
+        Mock Write-ErrorMessage { }
+        Mock Remove-Item { }
+        $script:killCalled = $false
+    }
+
+    It 'returns Ok when the upgrade exits 0' {
+        Mock Start-Process {
+            $p = [PSCustomObject]@{ ExitCode = 0 }
+            $p | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value { param($ms) $true }
+            $p | Add-Member -MemberType ScriptMethod -Name Kill -Value { }
+            $p
+        }
+        Mock Get-Content { 'Successfully installed' }
+
+        $result = Invoke-WingetPackageUpgrade -PackageId 'Test.App'
+
+        $result.Status | Should -Be 'Ok'
+        $result.Id | Should -Be 'Test.App'
+    }
+
+    It 'returns NoUpgrade when winget reports nothing to upgrade' {
+        Mock Start-Process {
+            $p = [PSCustomObject]@{ ExitCode = 0 }
+            $p | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value { param($ms) $true }
+            $p | Add-Member -MemberType ScriptMethod -Name Kill -Value { }
+            $p
+        }
+        Mock Get-Content { 'No available upgrade found' }
+
+        (Invoke-WingetPackageUpgrade -PackageId 'Test.App').Status | Should -Be 'NoUpgrade'
+    }
+
+    It 'returns Failed on a non-zero exit code' {
+        Mock Start-Process {
+            $p = [PSCustomObject]@{ ExitCode = 1 }
+            $p | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value { param($ms) $true }
+            $p | Add-Member -MemberType ScriptMethod -Name Kill -Value { }
+            $p
+        }
+        Mock Get-Content { 'install failed' }
+
+        (Invoke-WingetPackageUpgrade -PackageId 'Test.App').Status | Should -Be 'Failed'
+    }
+
+    It 'times out and kills the process when it does not exit in time' {
+        Mock Start-Process {
+            $p = [PSCustomObject]@{ ExitCode = 0 }
+            $p | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value { param($ms) $false }
+            $p | Add-Member -MemberType ScriptMethod -Name Kill -Value { Set-Variable -Name killCalled -Value $true -Scope script }
+            $p
+        }
+        Mock Get-Content { '' }
+
+        $result = Invoke-WingetPackageUpgrade -PackageId 'Test.App' -TimeoutSeconds 1
+
+        $result.Status | Should -Be 'TimedOut'
+        $script:killCalled | Should -BeTrue
+    }
+}
+
 Describe 'Test-CanUseGridView' {
     BeforeAll {
     }

--- a/WingetAppSetup/Private/WingetUpgrade.ps1
+++ b/WingetAppSetup/Private/WingetUpgrade.ps1
@@ -1,0 +1,64 @@
+<#
+.SYNOPSIS
+    Upgrades a single winget package with a hard timeout so a stalled upgrade cannot hang the run.
+.DESCRIPTION
+    Runs `winget upgrade` for one package id as a child process and waits up to TimeoutSeconds for it
+    to exit. If the process does not finish in time it is killed and reported as timed out, so the
+    caller can move on to the next package instead of blocking indefinitely (issue #120). This mirrors
+    the Start-Process/WaitForExit/Kill timeout pattern already used by Set-Sources.
+.PARAMETER PackageId
+    The exact winget package identifier to upgrade (for example, 'Warp.Warp').
+.PARAMETER TimeoutSeconds
+    Maximum seconds to wait for the upgrade before terminating it. Defaults to 300 (5 minutes).
+.RETURNS
+    [PSCustomObject] with Id, Status ('Ok' | 'NoUpgrade' | 'Failed' | 'TimedOut'), and ExitCode.
+#>
+function Invoke-WingetPackageUpgrade {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$PackageId,
+
+        [Parameter(Mandatory = $false)]
+        [int]$TimeoutSeconds = 300
+    )
+
+    $token = [guid]::NewGuid().ToString('N')
+    $outFile = Join-Path $env:TEMP "winget_upgrade_out_$token.txt"
+    $errFile = Join-Path $env:TEMP "winget_upgrade_err_$token.txt"
+
+    try {
+        $upgradeProcess = Start-Process -FilePath 'winget' `
+            -ArgumentList 'upgrade', '--id', $PackageId, '--exact', '--silent', '--disable-interactivity', '--accept-source-agreements', '--accept-package-agreements' `
+            -NoNewWindow `
+            -PassThru `
+            -RedirectStandardOutput $outFile `
+            -RedirectStandardError $errFile
+
+        if (-not $upgradeProcess.WaitForExit($TimeoutSeconds * 1000)) {
+            Write-WarningMessage "Update for $PackageId timed out after $TimeoutSeconds seconds. Terminating..."
+            try { $upgradeProcess.Kill() } catch { }
+            return [PSCustomObject]@{ Id = $PackageId; Status = 'TimedOut'; ExitCode = $null }
+        }
+
+        $exitCode = $upgradeProcess.ExitCode
+        $output = (Get-Content -Path $outFile -ErrorAction SilentlyContinue) -join "`n"
+
+        if ($output -match 'No available upgrade found' -or $output -match 'No newer package versions are available') {
+            return [PSCustomObject]@{ Id = $PackageId; Status = 'NoUpgrade'; ExitCode = $exitCode }
+        }
+
+        if ($exitCode -eq 0 -or $output -match 'Successfully installed') {
+            return [PSCustomObject]@{ Id = $PackageId; Status = 'Ok'; ExitCode = $exitCode }
+        }
+
+        return [PSCustomObject]@{ Id = $PackageId; Status = 'Failed'; ExitCode = $exitCode }
+    }
+    catch {
+        Write-ErrorMessage "Error updating ${PackageId}: $_"
+        return [PSCustomObject]@{ Id = $PackageId; Status = 'Failed'; ExitCode = $null }
+    }
+    finally {
+        Remove-Item -Path $outFile, $errFile -ErrorAction SilentlyContinue
+    }
+}

--- a/WingetAppSetup/Public/Install.ps1
+++ b/WingetAppSetup/Public/Install.ps1
@@ -280,20 +280,10 @@ function Invoke-WingetInstall {
         if (-not $WhatIf) {
             Write-Success 'Updates found. Installing updates...'
 
-            # Try PowerShell module first
-            if (Get-Command Update-WinGetPackage -ErrorAction SilentlyContinue) {
-                $updateResults = Get-WinGetPackage | Where-Object IsUpdateAvailable | Update-WinGetPackage
-
-                foreach ($result in $updateResults) {
-                    if ($result.Status -eq 'Ok') {
-                        $updatedApps += $result.Id
-                        Write-Success "Successfully updated: $($result.Id)"
-                    }
-                    else {
-                        $failedUpdateApps += $result.Id
-                        Write-ErrorMessage "Failed to update: $($result.Id) - $($result.Status)"
-                    }
-                }
+            # Enumerate the package ids that have updates, preferring the PowerShell module.
+            $updateIds = @()
+            if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+                $updateIds = @(Get-WinGetPackage | Where-Object IsUpdateAvailable | ForEach-Object { $_.Id })
             }
             else {
                 Write-WarningMessage 'PowerShell module not available, using CLI fallback...'
@@ -318,27 +308,31 @@ function Invoke-WingetInstall {
 
                         # Skip if it's not a winget package or if it's a system component
                         if ($packageId -and $packageId -notmatch '^(ARP|MSIX)') {
-                            try {
-                                $upgradeResult = & winget upgrade $packageId --source winget 2>&1
-                                $upgradeOutput = $upgradeResult | Out-String
-
-                                # Check if upgrade is available and successful
-                                if ($upgradeOutput -match 'Successfully installed') {
-                                    $updatedApps += $packageId
-                                    Write-Success "Successfully updated: $packageId"
-                                }
-                                elseif ($upgradeOutput -notmatch 'No available upgrade found' -and
-                                    $upgradeOutput -notmatch 'No newer package versions are available') {
-                                    # Package has an update but installation may have failed
-                                    $failedUpdateApps += $packageId
-                                    Write-ErrorMessage "Failed to update: $packageId"
-                                }
-                            }
-                            catch {
-                                $failedUpdateApps += $packageId
-                                Write-ErrorMessage "Error updating ${packageId}: $_"
-                            }
+                            $updateIds += $packageId
                         }
+                    }
+                }
+            }
+
+            # Upgrade each package through a timeout-guarded helper so a single stalled
+            # upgrade can no longer hang the entire run (issue #120).
+            foreach ($packageId in $updateIds) {
+                $result = Invoke-WingetPackageUpgrade -PackageId $packageId
+                switch ($result.Status) {
+                    'Ok' {
+                        $updatedApps += $packageId
+                        Write-Success "Successfully updated: $packageId"
+                    }
+                    'NoUpgrade' {
+                        # Nothing to do; the package was already current by the time we upgraded.
+                    }
+                    'TimedOut' {
+                        $failedUpdateApps += $packageId
+                        Write-ErrorMessage "Timed out updating: $packageId (skipped to continue)"
+                    }
+                    default {
+                        $failedUpdateApps += $packageId
+                        Write-ErrorMessage "Failed to update: $packageId"
                     }
                 }
             }

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -368,6 +368,72 @@ function Test-AndInstallGraphicalTools {
     return $false
 }
 
+# --- WingetUpgrade ---
+<#
+.SYNOPSIS
+    Upgrades a single winget package with a hard timeout so a stalled upgrade cannot hang the run.
+.DESCRIPTION
+    Runs `winget upgrade` for one package id as a child process and waits up to TimeoutSeconds for it
+    to exit. If the process does not finish in time it is killed and reported as timed out, so the
+    caller can move on to the next package instead of blocking indefinitely (issue #120). This mirrors
+    the Start-Process/WaitForExit/Kill timeout pattern already used by Set-Sources.
+.PARAMETER PackageId
+    The exact winget package identifier to upgrade (for example, 'Warp.Warp').
+.PARAMETER TimeoutSeconds
+    Maximum seconds to wait for the upgrade before terminating it. Defaults to 300 (5 minutes).
+.RETURNS
+    [PSCustomObject] with Id, Status ('Ok' | 'NoUpgrade' | 'Failed' | 'TimedOut'), and ExitCode.
+#>
+function Invoke-WingetPackageUpgrade {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$PackageId,
+
+        [Parameter(Mandatory = $false)]
+        [int]$TimeoutSeconds = 300
+    )
+
+    $token = [guid]::NewGuid().ToString('N')
+    $outFile = Join-Path $env:TEMP "winget_upgrade_out_$token.txt"
+    $errFile = Join-Path $env:TEMP "winget_upgrade_err_$token.txt"
+
+    try {
+        $upgradeProcess = Start-Process -FilePath 'winget' `
+            -ArgumentList 'upgrade', '--id', $PackageId, '--exact', '--silent', '--disable-interactivity', '--accept-source-agreements', '--accept-package-agreements' `
+            -NoNewWindow `
+            -PassThru `
+            -RedirectStandardOutput $outFile `
+            -RedirectStandardError $errFile
+
+        if (-not $upgradeProcess.WaitForExit($TimeoutSeconds * 1000)) {
+            Write-WarningMessage "Update for $PackageId timed out after $TimeoutSeconds seconds. Terminating..."
+            try { $upgradeProcess.Kill() } catch { }
+            return [PSCustomObject]@{ Id = $PackageId; Status = 'TimedOut'; ExitCode = $null }
+        }
+
+        $exitCode = $upgradeProcess.ExitCode
+        $output = (Get-Content -Path $outFile -ErrorAction SilentlyContinue) -join "`n"
+
+        if ($output -match 'No available upgrade found' -or $output -match 'No newer package versions are available') {
+            return [PSCustomObject]@{ Id = $PackageId; Status = 'NoUpgrade'; ExitCode = $exitCode }
+        }
+
+        if ($exitCode -eq 0 -or $output -match 'Successfully installed') {
+            return [PSCustomObject]@{ Id = $PackageId; Status = 'Ok'; ExitCode = $exitCode }
+        }
+
+        return [PSCustomObject]@{ Id = $PackageId; Status = 'Failed'; ExitCode = $exitCode }
+    }
+    catch {
+        Write-ErrorMessage "Error updating ${PackageId}: $_"
+        return [PSCustomObject]@{ Id = $PackageId; Status = 'Failed'; ExitCode = $null }
+    }
+    finally {
+        Remove-Item -Path $outFile, $errFile -ErrorAction SilentlyContinue
+    }
+}
+
 # --- AppValidation ---
 <#
 .SYNOPSIS
@@ -702,20 +768,10 @@ function Invoke-WingetInstall {
         if (-not $WhatIf) {
             Write-Success 'Updates found. Installing updates...'
 
-            # Try PowerShell module first
-            if (Get-Command Update-WinGetPackage -ErrorAction SilentlyContinue) {
-                $updateResults = Get-WinGetPackage | Where-Object IsUpdateAvailable | Update-WinGetPackage
-
-                foreach ($result in $updateResults) {
-                    if ($result.Status -eq 'Ok') {
-                        $updatedApps += $result.Id
-                        Write-Success "Successfully updated: $($result.Id)"
-                    }
-                    else {
-                        $failedUpdateApps += $result.Id
-                        Write-ErrorMessage "Failed to update: $($result.Id) - $($result.Status)"
-                    }
-                }
+            # Enumerate the package ids that have updates, preferring the PowerShell module.
+            $updateIds = @()
+            if (Get-Command Get-WinGetPackage -ErrorAction SilentlyContinue) {
+                $updateIds = @(Get-WinGetPackage | Where-Object IsUpdateAvailable | ForEach-Object { $_.Id })
             }
             else {
                 Write-WarningMessage 'PowerShell module not available, using CLI fallback...'
@@ -740,27 +796,31 @@ function Invoke-WingetInstall {
 
                         # Skip if it's not a winget package or if it's a system component
                         if ($packageId -and $packageId -notmatch '^(ARP|MSIX)') {
-                            try {
-                                $upgradeResult = & winget upgrade $packageId --source winget 2>&1
-                                $upgradeOutput = $upgradeResult | Out-String
-
-                                # Check if upgrade is available and successful
-                                if ($upgradeOutput -match 'Successfully installed') {
-                                    $updatedApps += $packageId
-                                    Write-Success "Successfully updated: $packageId"
-                                }
-                                elseif ($upgradeOutput -notmatch 'No available upgrade found' -and
-                                    $upgradeOutput -notmatch 'No newer package versions are available') {
-                                    # Package has an update but installation may have failed
-                                    $failedUpdateApps += $packageId
-                                    Write-ErrorMessage "Failed to update: $packageId"
-                                }
-                            }
-                            catch {
-                                $failedUpdateApps += $packageId
-                                Write-ErrorMessage "Error updating ${packageId}: $_"
-                            }
+                            $updateIds += $packageId
                         }
+                    }
+                }
+            }
+
+            # Upgrade each package through a timeout-guarded helper so a single stalled
+            # upgrade can no longer hang the entire run (issue #120).
+            foreach ($packageId in $updateIds) {
+                $result = Invoke-WingetPackageUpgrade -PackageId $packageId
+                switch ($result.Status) {
+                    'Ok' {
+                        $updatedApps += $packageId
+                        Write-Success "Successfully updated: $packageId"
+                    }
+                    'NoUpgrade' {
+                        # Nothing to do; the package was already current by the time we upgraded.
+                    }
+                    'TimedOut' {
+                        $failedUpdateApps += $packageId
+                        Write-ErrorMessage "Timed out updating: $packageId (skipped to continue)"
+                    }
+                    default {
+                        $failedUpdateApps += $packageId
+                        Write-ErrorMessage "Failed to update: $packageId"
                     }
                 }
             }


### PR DESCRIPTION
Fixes #120

## Summary

The post-install update phase could hang indefinitely on a single stalled package upgrade. Discovered during the full end-to-end install test, where the run froze for 5+ minutes on `Warp.Warp` (the upgrade child process had already exited, but the script never regained control). Targets `fix/106-module-refactor`.

## Root cause

The update phase piped every outdated package into one unbounded call:

```powershell
Get-WinGetPackage | Where-Object IsUpdateAvailable | Update-WinGetPackage
```

There was no timeout, and an in-process cmdlet can't be reliably cancelled — so one non-responsive upgrade blocked the entire run.

## Fix

- **New `Invoke-WingetPackageUpgrade` (private)** — upgrades a single package via `winget upgrade` as a child process and waits up to `TimeoutSeconds` (default 300). On timeout it kills the process and returns `TimedOut`; otherwise it returns `Ok` / `NoUpgrade` / `Failed`. This reuses the `Start-Process` / `WaitForExit` / `Kill` timeout idiom already used by `Set-Sources`.
- **`Invoke-WingetInstall`** — now enumerates the package ids that have updates (PowerShell module when available, CLI parse otherwise) and upgrades each through the timeout-guarded helper. A stalled package is reported (`Timed out updating: <id> (skipped to continue)`) and skipped instead of freezing the run.

`-WhatIf` dry-run behaviour is unchanged.

## Notes

- This fixes the **hang**. Whether the update phase should upgrade *every* outdated package (vs. only the curated install list) is a separate product decision and is out of scope here.

## Testing (Windows 11, PowerShell 7, Pester 5.7.1)

- `Invoke-Pester ./Test-WingetAppInstall.Tests.ps1` -> **129 passed / 0 failed / 1 skipped** (4 new tests for the helper: Ok / NoUpgrade / Failed / TimedOut+kill).
- `./build/Build-WingetInstallScript.ps1 -Check` -> passes (installer regenerated and in sync).

Docs: CHANGELOG.md and STATUS.md updated.
