### PR TITLE
feat: Add Claude Code GitHub automation (@claude workflow)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,45 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    # Only run when "@claude" is mentioned in the relevant comment, review, issue body, or issue title.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          # Authenticate with a Claude Pro/Max subscription OAuth token (generated via `claude setup-token`)
+          # instead of a pay-as-you-go ANTHROPIC_API_KEY. Stored as the CLAUDE_CODE_OAUTH_TOKEN repo secret.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Optional configuration (uncomment to customize):
+          # trigger_phrase: "@claude"
+          # claude_args: |
+          #   --model claude-sonnet-4-6
+          #   --max-turns 10


### PR DESCRIPTION
Fixes #124

## What

Adds `.github/workflows/claude.yml` based on the official [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) v1 example. Mentioning `@claude` in an issue or PR triggers AI-assisted automation (analyze code, implement features, fix bugs, open PRs).

## Authentication — subscription, not API billing

Uses a **Claude Pro/Max subscription OAuth token** instead of a pay-as-you-go `ANTHROPIC_API_KEY`:

```yaml
claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
```

This draws from the existing Max subscription quota (no extra API charges). GitHub Actions minutes are free for this public repo.

## Workflow details

- **Triggers:** `issue_comment`, `pull_request_review_comment`, `issues` (opened/assigned), `pull_request_review` (submitted)
- **Gate:** job runs only when `@claude` appears in the comment/review/issue body or title
- **Permissions:** `contents`/`pull-requests`/`issues` write, `id-token` write, `actions` read
- **Steps:** `actions/checkout@v6` → `anthropics/claude-code-action@v1`

## Manual prerequisites (outside this PR)

The workflow is inert until both are done:

1. Install the Claude GitHub App (https://github.com/apps/claude) on this repo.
2. Add the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (generated via `claude setup-token`).

## Testing

Static config only — no unit tests apply. Validated YAML structure against the official v1 example. End-to-end verification is to comment `@claude` on an issue/PR once the app + secret are in place.