### PR TITLE
feat: Run @claude workflow on windows-latest

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,7 +18,11 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    # Windows runner so @claude executes in a real Windows environment and can run this
+    # repo's PowerShell scripts and Pester tests natively. The action is a bash-based
+    # composite action; windows-latest provides Git Bash and the action skips its
+    # Linux-only steps on Windows (note: Linux subprocess sandboxing does not apply here).
+    runs-on: windows-latest
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Fixes #127

## What

Switches the Claude Code automation runner from `ubuntu-latest` to `windows-latest` so `@claude` runs in a real Windows environment and can execute this repo's PowerShell scripts and Pester tests natively. (This repo targets Windows only.)

```diff
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
```

Auth (`CLAUDE_CODE_OAUTH_TOKEN`) and `@claude` trigger gating are unchanged.

## Why this works on Windows

`anthropics/claude-code-action` is a **composite action** whose steps run under `shell: bash`. GitHub-hosted `windows-latest` ships Git Bash, and the action explicitly skips its Linux-only steps on Windows (`runner.os != 'Windows'`) rather than failing — so the maintainers anticipated Windows runners.

## Caveats (call-outs for review)

- **Not officially first-class** — Windows support isn't validated/documented by the action; treat the first run as the real test.
- **No Linux sandboxing** — the bubblewrap subprocess isolation is Linux-only and won't apply on Windows. The `@claude` trigger remains gated to write-access users, so the exposure is limited to collaborators.
- **Fallback if flaky** — keep `@claude` on `ubuntu-latest` and add a separate `windows-latest` Pester CI job instead.

## Testing

Config-only change. Post-merge smoke test: comment `@claude` on an issue and confirm it completes on the Windows runner (optionally have it run `Invoke-Pester`).