### PR TITLE
feat: Add windows-latest Pester CI; revert @claude to ubuntu-latest

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,11 +18,9 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    # Windows runner so @claude executes in a real Windows environment and can run this
-    # repo's PowerShell scripts and Pester tests natively. The action is a bash-based
-    # composite action; windows-latest provides Git Bash and the action skips its
-    # Linux-only steps on Windows (note: Linux subprocess sandboxing does not apply here).
-    runs-on: windows-latest
+    # ubuntu-latest: the action installs the Claude CLI here reliably (it cannot on
+    # windows-latest). Windows-specific test execution lives in windows-tests.yml.
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -1,0 +1,52 @@
+name: Windows Tests (Pester)
+
+# Runs the Pester v5 unit suite on a real Windows runner. This is where Windows-native
+# test execution happens, since the Claude Code action (claude.yml) cannot run on
+# windows-latest. @claude (on ubuntu) can read these results via `actions: read`.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pester:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run Pester
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          # windows-latest ships Pester 5, but pin to be safe in case the image changes.
+          if (-not (Get-Module -ListAvailable -Name Pester | Where-Object { $_.Version -ge [version]'5.0.0' })) {
+            Install-Module Pester -MinimumVersion 5.0.0 -Force -SkipPublisherCheck -Scope CurrentUser
+          }
+          Import-Module Pester -MinimumVersion 5.0.0
+
+          $config = New-PesterConfiguration
+          $config.Run.Path = './Test-WingetAppInstall.Tests.ps1'
+          $config.Run.Exit = $true               # non-zero exit on failure -> fails the step
+          $config.Output.Verbosity = 'Detailed'
+          $config.TestResult.Enabled = $true
+          $config.TestResult.OutputFormat = 'NUnitXml'
+          $config.TestResult.OutputPath = 'testResults.xml'
+          Invoke-Pester -Configuration $config
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pester-results
+          path: testResults.xml
+          if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented the repository's commit, PR, and metadata rules plus working GitHub CLI commands for labels and assignees inside `.github/copilot-instructions.md`.
 - Added automatic detection and repair of broken or missing winget package sources (#66).
 - Added automated Windows Terminal post-install configuration to set PowerShell 7 as the default profile and register Windows Terminal as the default terminal application via `HKCU:\Console\%%Startup` delegation values (#74).
+- Added Claude Code GitHub automation (`.github/workflows/claude.yml`): mention `@claude` on an issue or PR to trigger AI assistance, authenticated with a Claude Max subscription OAuth token (#125).
+- Added a `windows-latest` Pester CI workflow (`.github/workflows/windows-tests.yml`) that runs the `Test-WingetAppInstall.Tests.ps1` suite on every push to `main` and on pull requests (#130).
 
 ### Changed
 
 - Simplified the README to a two-step guide that starts with `Set-ExecutionPolicy Unrestricted -Scope Process -Force` followed by running `powershell -ExecutionPolicy Unrestricted -File .\winget-app-install.ps1`.
 - Configured the workspace's local Memory MCP storage plus `.gitignore` and `.vscode` settings so auto-generated knowledge graph data stays in the repo scope.
 - `Invoke-WingetInstall` now verifies and auto-repairs the winget package source before beginning app installations.
+- Claude Code automation runs on `ubuntu-latest`; Windows-native test execution moved to the dedicated Pester workflow, since the action cannot install the Claude CLI on Windows runners (#130).
 
 ### Removed
 


### PR DESCRIPTION
Fixes #130

## Context

Running `@claude` on `windows-latest` (#128) failed — the action cannot install the Claude CLI on Windows (`Failed to install Claude Code after 3 attempts`, run 27593108312), which left `main` broken for every `@claude` call. This implements the agreed **hybrid**.

## Changes

1. **Revert** `claude.yml`: `runs-on: windows-latest` → `ubuntu-latest` (restores the working, hardened automation).
2. **Add** `windows-tests.yml`: a dedicated `windows-latest` job that runs the Pester v5 suite (`Test-WingetAppInstall.Tests.ps1`) on every push to `main` and on PRs — `permissions: contents: read`, concurrency cancellation, NUnit results artifact.
3. **Update** `CHANGELOG.md` (Added: `@claude` automation + Windows Pester CI; Changed: runner).

## Result

- `@claude` works again on ubuntu and can read Windows CI results via its existing `actions: read` scope.
- Real Windows test execution happens in purpose-built CI — no dependency on the action supporting Windows.
- **This `pull_request` self-tests:** the new `windows-tests` job runs on this very PR, so its check status here is the validation.

## Testing

- Both workflow YAMLs validated (parse + correct `runs-on`/triggers).
- The `windows-tests` check on this PR confirms the Pester suite passes on `windows-latest`.
- After merge, a quick `@claude` smoke test on an issue confirms the ubuntu runner is healthy again.