### PR TITLE
fix: eliminate double winget execution in Invoke-WingetCommand (#134)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ PSScriptAnalyzerSettings.ps1
 
 # Pester
 TestResults.xml
+testResults.xml
 
 # Temporary files
 *.tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed (Unreleased)
 
+- Fixed double winget command execution in `Invoke-WingetCommand`: the function previously ran each winget command twice (once to display output, once to capture it), causing duplicate prompts and spurious "already installed" failures. It now invokes winget a single time, reading the exit code directly before any pipeline can reset `$LASTEXITCODE` (#134).
 - Cleaned up `Test-WingetAppInstall.Tests.ps1` so it no longer defines unused variables and satisfies the linter.
 - Fixed broken winget source scenario: when running as admin on a standard user account the "winget" source registration may be missing or broken; the script now detects and auto-repairs this condition instead of silently failing (#66).
 - Added Pester coverage for Windows Terminal default profile and terminal delegation configuration paths, and corrected an `IsWindows` read-only variable name collision in the test suite.

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -650,14 +650,22 @@ function Invoke-WingetCommand {
     # Parse command string into arguments properly, handling quoted arguments
     $commandArgs = ConvertTo-CommandArguments -Command $Command
 
-    # First execution: Display output to user with natural progress indicators
-    & winget $commandArgs
-
-    # Second execution: Capture output for parsing (suppresses progress bars and extra formatting)
-    # We use the second execution's exit code because it represents the final, complete state
+    # Single execution: invoke winget once, capturing all output (stdout + stderr) so we
+    # can both display it to the user and parse it. Running winget twice (as the previous
+    # implementation did) caused duplicate prompts and spurious "already installed" failures
+    # because the package state changed between the two invocations (see issue #134).
     try {
-        $commandOutput = & winget $commandArgs 2>&1 | Where-Object { $_ -notmatch '^[\s\-\|\\]*$' }
+        # Capture the raw output first so $LASTEXITCODE reflects winget's own exit code,
+        # not the exit code of a downstream pipeline element (e.g. Where-Object), which
+        # would otherwise reset it to 0.
+        $rawOutput = & winget $commandArgs 2>&1
         $exitCode = $LASTEXITCODE
+
+        # Echo the captured output to the user so they still see winget's progress/results.
+        $rawOutput | ForEach-Object { Write-Host $_ }
+
+        # Filter out blank lines and progress-bar artifacts before pattern parsing.
+        $commandOutput = $rawOutput | Where-Object { $_ -notmatch '^[\s\-\|\\]*$' }
     }
     catch {
         Write-ErrorMessage "Error capturing winget output: $($_)"


### PR DESCRIPTION
Fixes #134

## What changed
`Invoke-WingetCommand` previously executed each winget command **twice** — once to stream output to the user (`& winget $commandArgs`) and a second time to capture output for pattern parsing (`& winget $commandArgs 2>&1 | Where-Object ...`). Running the command twice meant install/update side effects were attempted twice, producing duplicate UAC / source-agreement prompts and spurious "already installed" failures because the package state changed between the two invocations.

The function now invokes winget a **single** time:
- Capture combined stdout+stderr into `$rawOutput` in one call.
- Read `$exitCode = $LASTEXITCODE` immediately, **before** any pipeline (e.g. `Where-Object`) can reset `$LASTEXITCODE` to `0`.
- Echo `$rawOutput` to the host so the user still sees winget's progress/results.
- Filter blank/progress-artifact lines from `$rawOutput` for pattern parsing.

Also added the lowercase `testResults.xml` to `.gitignore` (the existing entry only covered `TestResults.xml`).

## Testing / self-review
- `winget-app-install.ps1` parses clean via the PowerShell AST parser on pwsh 7.1 (Linux).
- The Pester tests that mock `winget` for this function **cannot run on Linux** — `winget` does not exist as a command, so Pester 5 cannot create the mock (`Could not find Command winget`). This is a pre-existing environment limitation, not introduced by this change; these tests run on the Windows CI workflow.
- Re-read the diff: exit-code capture now happens before any pipeline, output is preserved for the user via `Write-Host`, and the blank-line filter regex is unchanged.