### PR TITLE
docs: add STATUS.md and fix README execution-policy inconsistency (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `STATUS.md` describing the project's purpose, components, resolved/open issues, next steps, and prerequisites, per repository conventions (#136).
 - Documented the repository's commit, PR, and metadata rules plus working GitHub CLI commands for labels and assignees inside `.github/copilot-instructions.md`.
 - Added automatic detection and repair of broken or missing winget package sources (#66).
 - Added automated Windows Terminal post-install configuration to set PowerShell 7 as the default profile and register Windows Terminal as the default terminal application via `HKCU:\Console\%%Startup` delegation values (#74).
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed (Unreleased)
 
+- Reconciled the README one-line install command with the CHANGELOG: the `Set-ExecutionPolicy Unrestricted -Scope Process` snippet now includes `-Force`, matching the documented simplified form (#136).
 - Fixed double winget command execution in `Invoke-WingetCommand`: the function previously ran each winget command twice (once to display output, once to capture it), causing duplicate prompts and spurious "already installed" failures. It now invokes winget a single time, reading the exit code directly before any pipeline can reset `$LASTEXITCODE` (#134).
 - Cleaned up `Test-WingetAppInstall.Tests.ps1` so it no longer defines unused variables and satisfies the linter.
 - Fixed broken winget source scenario: when running as admin on a standard user account the "winget" source registration may be missing or broken; the script now detects and auto-repairs this condition instead of silently failing (#66).

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,51 @@
+# STATUS
+
+## What This Is
+
+`winget-app-setup` is a PowerShell automation suite for provisioning and maintaining a curated set of Windows applications with [winget](https://learn.microsoft.com/windows/package-manager/). The main installer trusts the required winget sources, self-heals broken source registrations, elevates when needed, installs or updates the curated app list, and can register a scheduled task for ongoing update checks. A companion uninstaller, an update helper, and a comprehensive Pester test suite round out the toolset. The scripts target **Windows PowerShell / PowerShell 7 on Windows**; they cannot run end-to-end on Linux or macOS because they depend on `winget`, the `Microsoft.WinGet.Client` module, and Windows-only cmdlets.
+
+## Current State — 2026-06-16
+
+Healthy. The `2026-review` integration branch is collecting the fixes from the 2026 code review (#134–#137). Each fix lands via its own squash-merged PR; an aggregate `2026-review → main` PR is open for human review and is intentionally **not** merged. All changed scripts parse clean under the PowerShell AST parser on pwsh 7, and the Pester suite's pass/fail set is unchanged from baseline on Linux (the only failures are pre-existing Windows-only environment limitations).
+
+### Components
+
+| File | Description |
+| --- | --- |
+| `winget-app-install.ps1` | Main installer: source trust/repair, elevation, curated app install/update, scheduled-update management, Windows Terminal configuration. |
+| `winget-app-uninstall.ps1` | Companion script that uninstalls a configurable list of applications. |
+| `Update-InstalledApps.ps1` | Standalone update helper invoked by the scheduled update task. |
+| `Test-WingetAppInstall.Tests.ps1` | Pester 5 unit-test suite; dot-sources the installer so tests exercise the real implementation. |
+| `Test-WindowsTerminalConfiguration.ps1` | Smoke-test validation for the Windows Terminal default-shell configuration. |
+| `readme.md` | Quick-start run instructions (clone-and-run and one-line-run). |
+| `CHANGELOG.md` | Keep a Changelog history. |
+
+### Resolved Issues
+
+| Issue | Description | PR |
+| --- | --- | --- |
+| [#134](https://github.com/J-MaFf/winget-app-setup/issues/134) | Double winget command execution in `Invoke-WingetCommand` | [#138](https://github.com/J-MaFf/winget-app-setup/pull/138) |
+| [#135](https://github.com/J-MaFf/winget-app-setup/issues/135) | Pester tests copied function bodies instead of dot-sourcing the script | [#139](https://github.com/J-MaFf/winget-app-setup/pull/139) |
+| [#136](https://github.com/J-MaFf/winget-app-setup/issues/136) | Missing `STATUS.md` and README/CHANGELOG execution-policy mismatch | this PR |
+| [#137](https://github.com/J-MaFf/winget-app-setup/issues/137) | `Test-Source-IsTrusted` violated the PowerShell verb-noun convention | pending |
+
+### Open Issues
+
+None tracked for the 2026-review cycle beyond #134–#137 above.
+
+## Natural Next Steps
+
+- Review and merge the aggregate `2026-review → main` PR once all four fixes are verified on a Windows machine.
+- Run the `windows-latest` Pester CI workflow (or a local Windows run) to confirm the winget-dependent tests pass — they cannot be exercised on the Linux dev VM.
+- Consider expanding test coverage for the scheduled-update and source-repair paths so more of the suite is mockable cross-platform.
+- Cut a tagged release and move the `[Unreleased]` CHANGELOG entries under a versioned heading.
+
+## Prerequisites to Run
+
+- **Windows 10/11** with [App Installer / winget](https://www.microsoft.com/p/app-installer/9nblggh4nns1) available.
+- **PowerShell 7+** recommended (Windows PowerShell 5.1 also works for the installer).
+- Permission to temporarily relax the execution policy for the current process, e.g.:
+  ```powershell
+  Set-ExecutionPolicy Unrestricted -Scope Process -Force
+  ```
+- To run the test suite: **Pester 5.x** (`Install-Module Pester -MinimumVersion 5.0`), then `Invoke-Pester -Path ./Test-WingetAppInstall.Tests.ps1`.

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ powershell -ExecutionPolicy Unrestricted -File .\winget-app-install.ps1
 No download/clone needed (one-line-run):
 
 ```powershell
-Set-ExecutionPolicy Unrestricted -Scope Process; irm "https://raw.githubusercontent.com/J-MaFf/winget-app-setup/refs/heads/main/winget-app-install.ps1" | iex
+Set-ExecutionPolicy Unrestricted -Scope Process -Force; irm "https://raw.githubusercontent.com/J-MaFf/winget-app-setup/refs/heads/main/winget-app-install.ps1" | iex
 ```
 
 The script will trust the required Winget sources, elevate if necessary, and install or update the curated app list. Repeat step 1 anytime you open a new PowerShell window before running it.


### PR DESCRIPTION
Fixes #136

## What changed
The repo conventions require a `STATUS.md`, and the README's one-line install command was inconsistent with the CHANGELOG.

- **Added `STATUS.md`** following the project template: *What This Is*, *Current State* (Components / Resolved Issues / Open Issues tables), *Natural Next Steps*, and *Prerequisites to Run*. It documents the 2026-review cycle and the Windows-only runtime constraints.
- **Reconciled the README:** the one-line-run snippet now reads `Set-ExecutionPolicy Unrestricted -Scope Process -Force; irm ... | iex`, matching the simplified form the CHANGELOG already describes (previously the README omitted `-Force`).
- Added CHANGELOG entries under **Added** (STATUS.md) and **Fixed** (README reconciliation).

## Testing / self-review
- Docs-only change; no script behavior affected.
- Verified the README snippet now matches the CHANGELOG text verbatim (`-Scope Process -Force`).
- STATUS.md renders as valid Markdown (tables, fenced code block) and links resolve to the correct issues/PRs.