### PR TITLE
feat: rename Test-Source-IsTrusted to Test-WingetSourceTrusted (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Renamed the `Test-Source-IsTrusted` function to `Test-WingetSourceTrusted` so it follows the PowerShell verb-noun convention (the old name embedded a hyphen in the noun segment and tripped a PSScriptAnalyzer warning); updated the call site and all test references (#137).
 - Refactored `Test-WingetAppInstall.Tests.ps1` to dot-source the real `winget-app-install.ps1` instead of copying function bodies verbatim into `BeforeAll`/`BeforeEach` blocks, so the suite now exercises the actual implementation and no longer drifts silently when the script changes. Removed 24 inline function copies across 12 `Describe` blocks and corrected the `Format-AppList` empty-input test to match the real function's mandatory `[string[]]` contract (#135).
 - Simplified the README to a two-step guide that starts with `Set-ExecutionPolicy Unrestricted -Scope Process -Force` followed by running `powershell -ExecutionPolicy Unrestricted -File .\winget-app-install.ps1`.
 - Configured the workspace's local Memory MCP storage plus `.gitignore` and `.vscode` settings so auto-generated knowledge graph data stays in the repo scope.

--- a/STATUS.md
+++ b/STATUS.md
@@ -26,8 +26,8 @@ Healthy. The `2026-review` integration branch is collecting the fixes from the 2
 | --- | --- | --- |
 | [#134](https://github.com/J-MaFf/winget-app-setup/issues/134) | Double winget command execution in `Invoke-WingetCommand` | [#138](https://github.com/J-MaFf/winget-app-setup/pull/138) |
 | [#135](https://github.com/J-MaFf/winget-app-setup/issues/135) | Pester tests copied function bodies instead of dot-sourcing the script | [#139](https://github.com/J-MaFf/winget-app-setup/pull/139) |
-| [#136](https://github.com/J-MaFf/winget-app-setup/issues/136) | Missing `STATUS.md` and README/CHANGELOG execution-policy mismatch | this PR |
-| [#137](https://github.com/J-MaFf/winget-app-setup/issues/137) | `Test-Source-IsTrusted` violated the PowerShell verb-noun convention | pending |
+| [#136](https://github.com/J-MaFf/winget-app-setup/issues/136) | Missing `STATUS.md` and README/CHANGELOG execution-policy mismatch | [#140](https://github.com/J-MaFf/winget-app-setup/pull/140) |
+| [#137](https://github.com/J-MaFf/winget-app-setup/issues/137) | Renamed `Test-Source-IsTrusted` to `Test-WingetSourceTrusted` for verb-noun compliance | this PR |
 
 ### Open Issues
 

--- a/Test-WingetAppInstall.Tests.ps1
+++ b/Test-WingetAppInstall.Tests.ps1
@@ -579,19 +579,19 @@ Describe 'Test-WingetSources' {
     }
 }
 
-Describe 'Test-Source-IsTrusted' {
+Describe 'Test-WingetSourceTrusted' {
     BeforeAll {
         Mock Write-Host { }
         Mock Write-Warning { }
 
-        # Dot-source the main script to import Test-Source-IsTrusted
+        # Dot-source the main script to import Test-WingetSourceTrusted
         . "$PSScriptRoot\winget-app-install.ps1"
     }
 
     Context 'When source is trusted' {
         It 'Should return true and accept source agreements' {
             Mock winget { return 'winget      https://cdn.winget.microsoft.com/cache        true' } -ParameterFilter { $args[0] -eq 'source' -and $args[1] -eq 'list' -and $args -contains '--disable-interactivity' }
-            $result = Test-Source-IsTrusted -target 'winget'
+            $result = Test-WingetSourceTrusted -target 'winget'
             $result | Should -Be $true
         }
     }
@@ -599,7 +599,7 @@ Describe 'Test-Source-IsTrusted' {
     Context 'When source is not trusted' {
         It 'Should return false' {
             Mock winget { return 'msstore      https://storeedgefd.dsx.mp.microsoft.com/v9.0        true' } -ParameterFilter { $args[0] -eq 'source' -and $args[1] -eq 'list' -and $args -contains '--disable-interactivity' }
-            $result = Test-Source-IsTrusted -target 'winget'
+            $result = Test-WingetSourceTrusted -target 'winget'
             $result | Should -Be $false
         }
     }
@@ -607,7 +607,7 @@ Describe 'Test-Source-IsTrusted' {
     Context 'When winget source list fails' {
         It 'Should return false and emit warning' {
             Mock winget { throw 'Command failed' } -ParameterFilter { $args[0] -eq 'source' -and $args[1] -eq 'list' -and $args -contains '--disable-interactivity' }
-            $result = Test-Source-IsTrusted -target 'winget'
+            $result = Test-WingetSourceTrusted -target 'winget'
             $result | Should -Be $false
             Assert-MockCalled Write-Warning -Times 1
         }
@@ -1350,12 +1350,12 @@ Describe 'Main Script Logic' {
 
     Context 'Source verification' {
         It 'Should check trusted sources' {
-            Mock Test-Source-IsTrusted { param($target) return $true } -ParameterFilter { $target -eq 'winget' }
-            Mock Test-Source-IsTrusted { param($target) return $true } -ParameterFilter { $target -eq 'msstore' }
+            Mock Test-WingetSourceTrusted { param($target) return $true } -ParameterFilter { $target -eq 'winget' }
+            Mock Test-WingetSourceTrusted { param($target) return $true } -ParameterFilter { $target -eq 'msstore' }
 
             $trustedSources = @('winget', 'msstore')
             foreach ($source in $trustedSources) {
-                Test-Source-IsTrusted -target $source | Should -Be $true
+                Test-WingetSourceTrusted -target $source | Should -Be $true
             }
         }
 
@@ -2257,13 +2257,13 @@ Describe 'WhatIf Mode - Unit Tests' {
             Mock Write-Info { }
             Mock Write-WarningMessage { }
             Mock Write-Success { }
-            Mock Test-Source-IsTrusted { return $false }
+            Mock Test-WingetSourceTrusted { return $false }
 
             # Simulate the code path
             $WhatIf = $true
             $source = 'winget'
 
-            if (-not (Test-Source-IsTrusted -target $source)) {
+            if (-not (Test-WingetSourceTrusted -target $source)) {
                 if (-not $WhatIf) {
                     Write-WarningMessage "Trusting source: $source"
                     Set-Sources
@@ -2282,13 +2282,13 @@ Describe 'WhatIf Mode - Unit Tests' {
             Mock Write-Info { }
             Mock Write-WarningMessage { }
             Mock Write-Success { }
-            Mock Test-Source-IsTrusted { return $false }
+            Mock Test-WingetSourceTrusted { return $false }
 
             # Simulate the code path
             $WhatIf = $false
             $source = 'winget'
 
-            if (-not (Test-Source-IsTrusted -target $source)) {
+            if (-not (Test-WingetSourceTrusted -target $source)) {
                 if (-not $WhatIf) {
                     Write-WarningMessage "Trusting source: $source"
                     Set-Sources

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -208,7 +208,7 @@ function Test-AppDefinitions {
 .RETURNS
     [bool] True if the source is trusted, otherwise False.
 #>
-function Test-Source-IsTrusted($target) {
+function Test-WingetSourceTrusted($target) {
     try {
         $sources = winget source list --disable-interactivity --accept-source-agreements 2>&1
         return $sources -match [regex]::Escape($target)
@@ -1835,7 +1835,7 @@ function Invoke-WingetInstall {
     $trustedSources = @('winget', 'msstore')
     $sourceErrors = @()
     ForEach ($source in $trustedSources) {
-        if (-not (Test-Source-IsTrusted -target $source)) {
+        if (-not (Test-WingetSourceTrusted -target $source)) {
             if (-not $WhatIf) {
                 Write-WarningMessage "Trusting source: $source"
                 try {


### PR DESCRIPTION
Fixes #137

## What changed
`Test-Source-IsTrusted` embedded a hyphen inside the noun segment, which violates the PowerShell verb-noun naming convention and triggers a PSScriptAnalyzer warning. Renamed to **`Test-WingetSourceTrusted`** (approved verb `Test` + single PascalCase noun).

- Renamed the function definition and its call site in `winget-app-install.ps1` (2 occurrences).
- Updated all references in `Test-WingetAppInstall.Tests.ps1`: the `Describe` block, its dot-source comment, and the `Mock`/usage sites in that block and in `Main Script Logic` (12 occurrences).
- Updated the `STATUS.md` #137 row and added a CHANGELOG **Changed** entry.

## Testing / self-review
- Both scripts parse clean via the PowerShell AST parser on pwsh 7 (Linux).
- No references to the old name remain in code — verified repo-wide; the only remaining mentions are in `STATUS.md` / `CHANGELOG.md` where the rename is intentionally documented.
- Full Pester run: **85 passed / 53 failed / 1 skipped** — an **identical failure set** to the pre-rename baseline (the 53 failures are the pre-existing Windows-only environment limitations; `winget` is absent on Linux). This is a pure rename with **no behavioral or test-status change** — confirmed by diffing the failing-test name set (after normalizing the renamed test names) before and after.