### PR TITLE
fix: retry transient 0x80073d19 session error during winget install

### DIFF
--- a/Test-WingetAppInstall.Tests.ps1
+++ b/Test-WingetAppInstall.Tests.ps1
@@ -1676,6 +1676,80 @@ Describe 'Retry Failed Installations' {
     }
 }
 
+Describe 'Install-WingetPackage (0x80073d19 session-error backoff)' {
+    BeforeAll {
+        # 0x80073D19 (ERROR_INSTALL_USER_LOGOFF) as the signed Int32 winget reports.
+        $script:SessionLogoffExitCode = -2147009255
+    }
+
+    BeforeEach {
+        Mock Write-Host { }
+        Mock Write-WarningMessage { }
+        # Never actually wait during tests; the backoff is verified via Assert-MockCalled.
+        Mock Start-Sleep { }
+
+        # Each Start-Process call returns the next exit code from the queue, simulating winget.
+        $script:exitCodeQueue = @()
+        $script:procCallIndex = 0
+        Mock Start-Process {
+            $code = $script:exitCodeQueue[$script:procCallIndex]
+            $script:procCallIndex++
+            [pscustomobject]@{ ExitCode = $code }
+        }
+    }
+
+    It 'Succeeds on the first attempt without sleeping' {
+        $script:exitCodeQueue = @(0)
+
+        $result = Install-WingetPackage -PackageId 'Test.App' -MaxAttempts 3 -InitialDelaySeconds 1
+
+        $result.ExitCode | Should -Be 0
+        $result.Attempts | Should -Be 1
+        $result.SessionErrorExhausted | Should -Be $false
+        Assert-MockCalled Start-Process -Times 1 -Exactly
+        Assert-MockCalled Start-Sleep -Times 0 -Exactly
+    }
+
+    It 'Retries with backoff and recovers when the session error is transient' {
+        $script:exitCodeQueue = @($script:SessionLogoffExitCode, 0)
+
+        $result = Install-WingetPackage -PackageId 'Microsoft.PowerShell' -MaxAttempts 3 -InitialDelaySeconds 1
+
+        $result.ExitCode | Should -Be 0
+        $result.Attempts | Should -Be 2
+        $result.SessionErrorExhausted | Should -Be $false
+        Assert-MockCalled Start-Process -Times 2 -Exactly
+        # One backoff wait between the failed first attempt and the successful second.
+        Assert-MockCalled Start-Sleep -Times 1 -Exactly
+    }
+
+    It 'Exhausts MaxAttempts when the session error persists' {
+        $script:exitCodeQueue = @($script:SessionLogoffExitCode, $script:SessionLogoffExitCode, $script:SessionLogoffExitCode)
+
+        $result = Install-WingetPackage -PackageId 'Microsoft.PowerShell' -MaxAttempts 3 -InitialDelaySeconds 1
+
+        $result.ExitCode | Should -Be $script:SessionLogoffExitCode
+        $result.Attempts | Should -Be 3
+        $result.SessionErrorExhausted | Should -Be $true
+        Assert-MockCalled Start-Process -Times 3 -Exactly
+        # Sleeps between attempts only (1->2 and 2->3), never after the final attempt.
+        Assert-MockCalled Start-Sleep -Times 2 -Exactly
+    }
+
+    It 'Does not retry a non-session failure (lets the caller verify)' {
+        # -1978335189 = "No applicable update found"; any non-session code must stop immediately.
+        $script:exitCodeQueue = @(-1978335189)
+
+        $result = Install-WingetPackage -PackageId 'Test.App' -MaxAttempts 3 -InitialDelaySeconds 1
+
+        $result.ExitCode | Should -Be -1978335189
+        $result.Attempts | Should -Be 1
+        $result.SessionErrorExhausted | Should -Be $false
+        Assert-MockCalled Start-Process -Times 1 -Exactly
+        Assert-MockCalled Start-Sleep -Times 0 -Exactly
+    }
+}
+
 Describe 'App list consistency' {
     It 'Should keep install and uninstall app lists in sync' {
         $installApps = Get-Content "$PSScriptRoot\winget-app-install.ps1" |

--- a/WingetAppSetup/Public/Install.ps1
+++ b/WingetAppSetup/Public/Install.ps1
@@ -223,7 +223,9 @@ function Invoke-WingetInstall {
             if (![String]::Join('', $listApp).Contains($app.name)) {
                 if (-not $WhatIf) {
                     Write-Info "Installing: $($app.name)"
-                    Start-Process winget -ArgumentList "install -e --accept-source-agreements --accept-package-agreements --source winget --id $($app.name)" -NoNewWindow -Wait
+                    # Install through the helper so the transient 0x80073d19 session error is
+                    # retried with backoff (issue #150) instead of failing on the first hit.
+                    [void](Install-WingetPackage -PackageId $app.name)
 
                     # Verify installation with timeout
                     $verifyProcess = Start-Process -FilePath 'winget' `
@@ -368,7 +370,9 @@ function Invoke-WingetInstall {
             foreach ($appName in $appsToRetry) {
                 try {
                     Write-Info "Retrying: $appName"
-                    Start-Process winget -ArgumentList "install -e --accept-source-agreements --accept-package-agreements --source winget --id $appName" -NoNewWindow -Wait
+                    # Route the final retry through the same helper so a lingering 0x80073d19
+                    # session error gets its backoff retries here too (issue #150).
+                    [void](Install-WingetPackage -PackageId $appName)
 
                     # Verify installation with timeout
                     $verifyProcess = Start-Process -FilePath 'winget' `

--- a/WingetAppSetup/Public/WingetCore.ps1
+++ b/WingetAppSetup/Public/WingetCore.ps1
@@ -550,3 +550,84 @@ function Initialize-WingetSourcesForUser {
     }
 }
 
+<#
+.SYNOPSIS
+    Installs a single winget package, retrying the transient 0x80073d19 session error with backoff.
+.DESCRIPTION
+    Runs `winget install` for one package id and captures winget's real process exit code via
+    Start-Process -PassThru -Wait. Exit code 0x80073d19 (ERROR_INSTALL_USER_LOGOFF — "an error
+    occurred because a user was logged off") is a transient MSIX/session-deployment race: an
+    immediate retry simply hits the same race, which is why issues #81/#100/#102 left it unresolved.
+    When that specific code is seen, this function waits with an increasing backoff and retries, up
+    to MaxAttempts. Any other exit code (success or a real failure) is returned immediately so the
+    caller can verify the result with `winget list` as before.
+
+    winget's output is intentionally left unredirected so its native progress is still shown to the
+    user; the session error is identified purely from the exit code, which winget reports as
+    0x80073d19 for this failure.
+.PARAMETER PackageId
+    The winget package id to install (e.g. 'Microsoft.PowerShell').
+.PARAMETER MaxAttempts
+    Maximum number of install attempts while the session error keeps recurring. Default 3.
+.PARAMETER InitialDelaySeconds
+    Seconds to wait before the first retry; the wait doubles on each subsequent retry. Default 5.
+.RETURNS
+    [hashtable] @{ ExitCode = <int>; Attempts = <int>; SessionErrorExhausted = <bool> }
+    SessionErrorExhausted is True only when every attempt failed with the session error.
+#>
+function Install-WingetPackage {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$PackageId,
+
+        [Parameter(Mandatory = $false)]
+        [int]$MaxAttempts = 3,
+
+        [Parameter(Mandatory = $false)]
+        [int]$InitialDelaySeconds = 5
+    )
+
+    # 0x80073D19 (ERROR_INSTALL_USER_LOGOFF) as a signed Int32, which is how winget reports it
+    # through Process.ExitCode.
+    $sessionLogoffExitCode = -2147009255
+
+    $attempt = 0
+    $delay = $InitialDelaySeconds
+    $exitCode = 0
+
+    while ($attempt -lt $MaxAttempts) {
+        $attempt++
+
+        $installArgs = @(
+            'install', '-e',
+            '--accept-source-agreements', '--accept-package-agreements',
+            '--source', 'winget',
+            '--id', $PackageId
+        )
+
+        $proc = Start-Process -FilePath 'winget' -ArgumentList $installArgs -NoNewWindow -Wait -PassThru
+        $exitCode = $proc.ExitCode
+
+        # Anything other than the transient session error (success or a real failure) is final here;
+        # the caller verifies the actual install state with `winget list`.
+        if ($exitCode -ne $sessionLogoffExitCode) {
+            break
+        }
+
+        if ($attempt -lt $MaxAttempts) {
+            Write-WarningMessage "Install of $PackageId hit transient session error 0x80073D19 (a user was logged off). Waiting ${delay}s before retry $($attempt + 1) of ${MaxAttempts}..."
+            Start-Sleep -Seconds $delay
+            $delay = $delay * 2
+        }
+        else {
+            Write-WarningMessage "Install of $PackageId still failing with session error 0x80073D19 after ${MaxAttempts} attempts."
+        }
+    }
+
+    return @{
+        ExitCode              = $exitCode
+        Attempts              = $attempt
+        SessionErrorExhausted = ($exitCode -eq $sessionLogoffExitCode)
+    }
+}
+

--- a/WingetAppSetup/WingetAppSetup.psd1
+++ b/WingetAppSetup/WingetAppSetup.psd1
@@ -13,7 +13,7 @@
         'Test-AppDefinitions',
         # Winget core
         'Test-AndInstallWingetModule', 'Test-AndInstallWinget', 'Test-WingetSourceTrusted', 'Set-Sources', 'Test-WingetSources',
-        'Invoke-WingetCommand', 'Test-UpdatesAvailable', 'Get-UpdateReport', 'Initialize-WingetSourcesForUser',
+        'Invoke-WingetCommand', 'Test-UpdatesAvailable', 'Get-UpdateReport', 'Initialize-WingetSourcesForUser', 'Install-WingetPackage',
         # Scheduled / on-demand updates
         'Get-UpdateSettingsPaths', 'New-DefaultUpdateConfiguration', 'Get-UpdateConfiguration', 'Save-UpdateConfiguration',
         'Test-ScheduledUpdatesTaskExists', 'Install-UpdateHelperScript', 'Enable-ScheduledUpdatesCheck',

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -716,7 +716,9 @@ function Invoke-WingetInstall {
             if (![String]::Join('', $listApp).Contains($app.name)) {
                 if (-not $WhatIf) {
                     Write-Info "Installing: $($app.name)"
-                    Start-Process winget -ArgumentList "install -e --accept-source-agreements --accept-package-agreements --source winget --id $($app.name)" -NoNewWindow -Wait
+                    # Install through the helper so the transient 0x80073d19 session error is
+                    # retried with backoff (issue #150) instead of failing on the first hit.
+                    [void](Install-WingetPackage -PackageId $app.name)
 
                     # Verify installation with timeout
                     $verifyProcess = Start-Process -FilePath 'winget' `
@@ -861,7 +863,9 @@ function Invoke-WingetInstall {
             foreach ($appName in $appsToRetry) {
                 try {
                     Write-Info "Retrying: $appName"
-                    Start-Process winget -ArgumentList "install -e --accept-source-agreements --accept-package-agreements --source winget --id $appName" -NoNewWindow -Wait
+                    # Route the final retry through the same helper so a lingering 0x80073d19
+                    # session error gets its backoff retries here too (issue #150).
+                    [void](Install-WingetPackage -PackageId $appName)
 
                     # Verify installation with timeout
                     $verifyProcess = Start-Process -FilePath 'winget' `
@@ -2241,6 +2245,87 @@ function Initialize-WingetSourcesForUser {
         Write-WarningMessage "Error initializing winget sources: $_"
         Write-WarningMessage 'Continuing with installation; retry logic will handle any session errors.'
         return $true
+    }
+}
+
+<#
+.SYNOPSIS
+    Installs a single winget package, retrying the transient 0x80073d19 session error with backoff.
+.DESCRIPTION
+    Runs `winget install` for one package id and captures winget's real process exit code via
+    Start-Process -PassThru -Wait. Exit code 0x80073d19 (ERROR_INSTALL_USER_LOGOFF — "an error
+    occurred because a user was logged off") is a transient MSIX/session-deployment race: an
+    immediate retry simply hits the same race, which is why issues #81/#100/#102 left it unresolved.
+    When that specific code is seen, this function waits with an increasing backoff and retries, up
+    to MaxAttempts. Any other exit code (success or a real failure) is returned immediately so the
+    caller can verify the result with `winget list` as before.
+
+    winget's output is intentionally left unredirected so its native progress is still shown to the
+    user; the session error is identified purely from the exit code, which winget reports as
+    0x80073d19 for this failure.
+.PARAMETER PackageId
+    The winget package id to install (e.g. 'Microsoft.PowerShell').
+.PARAMETER MaxAttempts
+    Maximum number of install attempts while the session error keeps recurring. Default 3.
+.PARAMETER InitialDelaySeconds
+    Seconds to wait before the first retry; the wait doubles on each subsequent retry. Default 5.
+.RETURNS
+    [hashtable] @{ ExitCode = <int>; Attempts = <int>; SessionErrorExhausted = <bool> }
+    SessionErrorExhausted is True only when every attempt failed with the session error.
+#>
+function Install-WingetPackage {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$PackageId,
+
+        [Parameter(Mandatory = $false)]
+        [int]$MaxAttempts = 3,
+
+        [Parameter(Mandatory = $false)]
+        [int]$InitialDelaySeconds = 5
+    )
+
+    # 0x80073D19 (ERROR_INSTALL_USER_LOGOFF) as a signed Int32, which is how winget reports it
+    # through Process.ExitCode.
+    $sessionLogoffExitCode = -2147009255
+
+    $attempt = 0
+    $delay = $InitialDelaySeconds
+    $exitCode = 0
+
+    while ($attempt -lt $MaxAttempts) {
+        $attempt++
+
+        $installArgs = @(
+            'install', '-e',
+            '--accept-source-agreements', '--accept-package-agreements',
+            '--source', 'winget',
+            '--id', $PackageId
+        )
+
+        $proc = Start-Process -FilePath 'winget' -ArgumentList $installArgs -NoNewWindow -Wait -PassThru
+        $exitCode = $proc.ExitCode
+
+        # Anything other than the transient session error (success or a real failure) is final here;
+        # the caller verifies the actual install state with `winget list`.
+        if ($exitCode -ne $sessionLogoffExitCode) {
+            break
+        }
+
+        if ($attempt -lt $MaxAttempts) {
+            Write-WarningMessage "Install of $PackageId hit transient session error 0x80073D19 (a user was logged off). Waiting ${delay}s before retry $($attempt + 1) of ${MaxAttempts}..."
+            Start-Sleep -Seconds $delay
+            $delay = $delay * 2
+        }
+        else {
+            Write-WarningMessage "Install of $PackageId still failing with session error 0x80073D19 after ${MaxAttempts} attempts."
+        }
+    }
+
+    return @{
+        ExitCode              = $exitCode
+        Attempts              = $attempt
+        SessionErrorExhausted = ($exitCode -eq $sessionLogoffExitCode)
     }
 }
 


### PR DESCRIPTION
Fixes #150

## Problem
`Microsoft.PowerShell` still failed to install with `0x80073d19`
(`ERROR_INSTALL_USER_LOGOFF`) despite the earlier attempts in #81 / #100 / #102.

Root cause: the install path in `Invoke-WingetInstall` ran winget via
`Start-Process -Wait` **without `-PassThru`**, so winget's exit code was never
captured — success/failure was inferred only from a follow-up `winget list`.
The "final retry" pass then re-ran the install **immediately with no backoff**,
which just hits the same transient MSIX/session-deployment race again.

## Fix
- New `Install-WingetPackage` helper (`WingetAppSetup/Public/WingetCore.ps1`)
  captures winget's real exit code and, on `0x80073d19` **specifically**, retries
  with exponential backoff (default 3 attempts; 5s then 10s) before giving up.
  Any other exit code returns immediately, so the caller's `winget list`
  verification still owns the final success/failure decision.
- Both the main install loop and the final retry pass in `Invoke-WingetInstall`
  now route through the helper.
- Regenerated `winget-app-install.ps1` from the module.

## Testing
- New Pester cases in `Test-WingetAppInstall.Tests.ps1`:
  - succeeds first try without sleeping
  - retries with backoff and recovers on a transient session error
  - exhausts `MaxAttempts` when the error persists
  - does not retry a non-session failure
- Full suite locally (pwsh 7.6.2 / Pester 5.7.1): **133 passed, 1 skipped, 0 failed**.
- `build/Build-WingetInstallScript.ps1 -Check` passes (generated script in sync).
- Authoritative validation runs on the `windows-latest` runner via `windows-tests.yml`.