### PR TITLE
chore: add bd-required gitignore patterns for Dolt embedded mode

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -78,3 +78,8 @@ bd.db
 # They would override fork protection in .git/info/exclude.
 # Config files (metadata.json, config.yaml) are tracked by git by default
 # since no pattern above ignores them.
+
+# Added by bd (missing required patterns)
+last_pull
+proxieddb/
+proxied_server_client_info.json


### PR DESCRIPTION
## Summary
- `bd bootstrap` auto-patches `.beads/.gitignore` with patterns required for Dolt embedded mode (`last_pull`, `proxieddb/`, `proxied_server_client_info.json`)
- Captured while bootstrapping beads on the MacBook per #149

Part of #149

## Test plan
- [x] `bd ready` / `bd show wgt-61k` resolve the synced graph on the MacBook
- [x] Round-trip: created `wgt-fj4` on MacBook, `bd dolt push`, pulled cleanly in a fresh clone, closed and pushed again