### PR TITLE
fix: bootstrap winget per-user state for cross-user elevation (0x80073d19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the recurring `0x80073d19` install failure ("an error occurred because a user was logged off") that persisted through #81/#104/#107/#150 on machines where the script is elevated as a different account than the interactively logged-on user. Root cause: `0x80073d19` is `ERROR_DEPLOYMENT_BLOCKED_BY_USER_LOG_OFF` — the AppX deployment service blocks winget's per-user first-use bootstrap (registering `Microsoft.Winget.Source`) for an account with no interactive logon session, so no amount of retrying could recover. `Initialize-WingetSourcesForUser` is rewritten to probe with `winget source update --accept-source-agreements` (its old probe omitted the flag and its fallback checked a wrong exit code, making it a no-op) and to bootstrap the account via `Repair-WinGetPackageManager` when the probe fails; `Test-AndInstallWinget` prefers the same bootstrap over `Add-AppxPackage`; cross-user elevation is now detected and reported with remediation guidance; and `Install-WingetPackage` prefers `--scope machine` (falling back automatically for MSIX-only packages like Windows Terminal), which both avoids per-user MSIX deployment — the layer `0x80073d19` blocks, and what Microsoft.PowerShell's default user-scope MSIX installer hit — and stops installs from landing in the elevated admin account's profile instead of machine-wide ([#159](https://github.com/J-MaFf/winget-app-setup/issues/159)).
+
 ### Added
 
 - Wired `build/Build-WingetInstallScript.ps1 -Check` into the Windows CI workflow (`.github/workflows/windows-tests.yml`) so every push and pull request verifies the generated `winget-app-install.ps1` is byte-for-byte in sync with the `WingetAppSetup` module and passes the undefined-reference guard; drift now fails CI instead of shipping silently ([#156](https://github.com/J-MaFf/winget-app-setup/issues/156), [#157](https://github.com/J-MaFf/winget-app-setup/pull/157)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ This repo targets **Windows only**. All scripts are PowerShell.
 
 ## Winget Notes
 
-- Exit code `0x80073d19` is a transient Windows session error. It is mitigated by initializing winget sources in the user context before elevation (`Initialize-WingetSourcesForUser`, issues #104/#105); any install that still fails is retried once in the final retry pass of `Invoke-WingetInstall`. (There is no dedicated backoff-retry function.)
+- Exit code `0x80073d19` (`ERROR_DEPLOYMENT_BLOCKED_BY_USER_LOG_OFF`) is an AppX deployment error: per-user MSIX registration is blocked when the invoking account has no interactive logon session — the classic case is elevating as a different admin account on a user's machine. Mitigations (issue #159): `Initialize-WingetSourcesForUser` probes with `winget source update --accept-source-agreements` and bootstraps the account via `Repair-WinGetPackageManager` on failure; `Install-WingetPackage` prefers `--scope machine` (auto-falls back for MSIX-only packages) and retries a still-transient `0x80073d19` with backoff (issue #150).
 - Always capture `$LASTEXITCODE` immediately after a winget call — it goes stale fast
 - Validate package IDs with regex before trusting winget output: `^[\w][\w.\-]+\.[\w][\w.\-]+`
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -11,9 +11,17 @@ scripts target **Windows PowerShell / PowerShell 7 on Windows**; they cannot run
 Linux or macOS because they depend on `winget`, the `Microsoft.WinGet.Client` module, and
 Windows-only cmdlets.
 
-## Current State — 2026-07-01
+## Current State — 2026-07-05
 
-Healthy. **One-liner install fixed** ([#154](https://github.com/J-MaFf/winget-app-setup/issues/154)):
+Healthy. **Cross-user `0x80073d19` root cause fixed** ([#159](https://github.com/J-MaFf/winget-app-setup/issues/159)):
+the error that persisted through #81/#104/#107/#150 is `ERROR_DEPLOYMENT_BLOCKED_BY_USER_LOG_OFF` —
+when the script is elevated as a different account than the logged-on user, winget's per-user MSIX
+bootstrap is blocked because that account has no interactive logon session. The installer now
+bootstraps the account via `Repair-WinGetPackageManager`, persists source agreements with a proper
+probe, detects cross-user elevation, and installs with `--scope machine` (auto-fallback for
+MSIX-only packages such as Windows Terminal).
+
+**One-liner install fixed** ([#154](https://github.com/J-MaFf/winget-app-setup/issues/154)):
 the `#106` module extraction had dropped `Test-SystemRequirements` without carrying it into the
 module, so the default `irm | iex` path threw `CommandNotFoundException`. The function is restored as
 `WingetAppSetup/Public/SystemChecks.ps1`, and the build now fails when the generated installer calls

--- a/Test-WingetAppInstall.Tests.ps1
+++ b/Test-WingetAppInstall.Tests.ps1
@@ -1748,6 +1748,222 @@ Describe 'Install-WingetPackage (0x80073d19 session-error backoff)' {
         Assert-MockCalled Start-Process -Times 1 -Exactly
         Assert-MockCalled Start-Sleep -Times 0 -Exactly
     }
+
+    It 'Prefers machine scope on the first attempt (issue #159)' {
+        $script:exitCodeQueue = @(0)
+
+        $result = Install-WingetPackage -PackageId 'Microsoft.PowerShell' -MaxAttempts 3 -InitialDelaySeconds 1
+
+        $result.MachineScopeFellBack | Should -Be $false
+        Assert-MockCalled Start-Process -Times 1 -Exactly -ParameterFilter {
+            ($ArgumentList -contains '--scope') -and ($ArgumentList -contains 'machine')
+        }
+    }
+
+    It 'Falls back to default scope when the package has no machine-scope installer' {
+        # -1978335216 = 0x8A150010 NO_APPLICABLE_INSTALLER (e.g. MSIX-only Microsoft.WindowsTerminal).
+        $script:exitCodeQueue = @(-1978335216, 0)
+
+        $result = Install-WingetPackage -PackageId 'Microsoft.WindowsTerminal' -MaxAttempts 3 -InitialDelaySeconds 1
+
+        $result.ExitCode | Should -Be 0
+        $result.MachineScopeFellBack | Should -Be $true
+        # The scope fallback is not a session-error retry: it must not consume an attempt or sleep.
+        $result.Attempts | Should -Be 1
+        Assert-MockCalled Start-Process -Times 2 -Exactly
+        Assert-MockCalled Start-Process -Times 1 -Exactly -ParameterFilter { $ArgumentList -notcontains '--scope' }
+        Assert-MockCalled Start-Sleep -Times 0 -Exactly
+    }
+
+    It 'Falls back on scope at most once' {
+        # NO_APPLICABLE_INSTALLER at both scopes is a real failure and must be returned, not looped.
+        $script:exitCodeQueue = @(-1978335216, -1978335216)
+
+        $result = Install-WingetPackage -PackageId 'Broken.Package' -MaxAttempts 3 -InitialDelaySeconds 1
+
+        $result.ExitCode | Should -Be -1978335216
+        $result.MachineScopeFellBack | Should -Be $true
+        Assert-MockCalled Start-Process -Times 2 -Exactly
+        Assert-MockCalled Start-Sleep -Times 0 -Exactly
+    }
+
+    It 'Still retries the session error with backoff after a scope fallback' {
+        $script:exitCodeQueue = @(-1978335216, $script:SessionLogoffExitCode, 0)
+
+        $result = Install-WingetPackage -PackageId 'Microsoft.WindowsTerminal' -MaxAttempts 3 -InitialDelaySeconds 1
+
+        $result.ExitCode | Should -Be 0
+        $result.MachineScopeFellBack | Should -Be $true
+        $result.Attempts | Should -Be 2
+        $result.SessionErrorExhausted | Should -Be $false
+        Assert-MockCalled Start-Process -Times 3 -Exactly
+        Assert-MockCalled Start-Sleep -Times 1 -Exactly
+    }
+}
+
+Describe 'Invoke-WingetSourceProbe' {
+    BeforeEach {
+        Mock Write-Host { }
+        Mock Write-WarningMessage { }
+        Mock Remove-Item { }
+    }
+
+    It 'Runs winget source update with agreement acceptance and reports success' {
+        Mock Start-Process {
+            $p = [pscustomobject]@{ ExitCode = 0 }
+            $p | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value { param($ms) $true }
+            $p | Add-Member -MemberType ScriptMethod -Name Kill -Value { }
+            $p
+        }
+
+        $result = Invoke-WingetSourceProbe
+
+        $result.Succeeded | Should -Be $true
+        $result.ExitCode | Should -Be 0
+        $result.TimedOut | Should -Be $false
+        Assert-MockCalled Start-Process -Times 1 -Exactly -ParameterFilter {
+            ($ArgumentList -contains 'source') -and
+            ($ArgumentList -contains 'update') -and
+            ($ArgumentList -contains '--accept-source-agreements') -and
+            ($ArgumentList -contains '--disable-interactivity')
+        }
+    }
+
+    It 'Passes through a failure exit code' {
+        Mock Start-Process {
+            # -2147009255 = 0x80073D19 ERROR_DEPLOYMENT_BLOCKED_BY_USER_LOG_OFF
+            $p = [pscustomobject]@{ ExitCode = -2147009255 }
+            $p | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value { param($ms) $true }
+            $p | Add-Member -MemberType ScriptMethod -Name Kill -Value { }
+            $p
+        }
+
+        $result = Invoke-WingetSourceProbe
+
+        $result.Succeeded | Should -Be $false
+        $result.ExitCode | Should -Be -2147009255
+        $result.TimedOut | Should -Be $false
+    }
+
+    It 'Kills the process and reports a timeout when winget hangs' {
+        $script:probeKillCalled = $false
+        Mock Start-Process {
+            $p = [pscustomobject]@{ ExitCode = 0 }
+            $p | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value { param($ms) $false }
+            $p | Add-Member -MemberType ScriptMethod -Name Kill -Value { Set-Variable -Name probeKillCalled -Value $true -Scope script }
+            $p
+        }
+
+        $result = Invoke-WingetSourceProbe -TimeoutSeconds 1
+
+        $result.Succeeded | Should -Be $false
+        $result.TimedOut | Should -Be $true
+        $result.ExitCode | Should -Be $null
+        $script:probeKillCalled | Should -Be $true
+    }
+
+    It 'Reports failure without throwing when winget cannot start' {
+        Mock Start-Process { throw 'winget not found' }
+
+        $result = Invoke-WingetSourceProbe
+
+        $result.Succeeded | Should -Be $false
+        $result.ExitCode | Should -Be $null
+        $result.TimedOut | Should -Be $false
+    }
+}
+
+Describe 'Initialize-WingetSourcesForUser (cross-user bootstrap, issue #159)' {
+    BeforeAll {
+        # Stub so the cmdlet can be mocked on machines without the Microsoft.WinGet.Client module.
+        function Repair-WinGetPackageManager { param([switch]$Latest, [switch]$Force) }
+    }
+
+    BeforeEach {
+        Mock Write-Host { }
+        Mock Write-WarningMessage { }
+        Mock Repair-WinGetPackageManager { }
+        Mock Get-ProcessUserName { 'CONTOSO\admin-jmaffiola' }
+        Mock Get-InteractiveSessionUserName { 'CONTOSO\admin-jmaffiola' }
+        # Repair-WinGetPackageManager resolves as available unless a test overrides this.
+        Mock Get-Command { [pscustomobject]@{ Name = 'Repair-WinGetPackageManager' } } -ParameterFilter { $Name -eq 'Repair-WinGetPackageManager' }
+    }
+
+    It 'Reports the dry run without probing' {
+        Mock Invoke-WingetSourceProbe { @{ Succeeded = $true; ExitCode = 0; TimedOut = $false } }
+
+        $result = Initialize-WingetSourcesForUser -WhatIf
+
+        $result | Should -Be $true
+        Assert-MockCalled Invoke-WingetSourceProbe -Times 0 -Exactly
+    }
+
+    It 'Returns true without repairing when the probe succeeds' {
+        Mock Invoke-WingetSourceProbe { @{ Succeeded = $true; ExitCode = 0; TimedOut = $false } }
+
+        $result = Initialize-WingetSourcesForUser
+
+        $result | Should -Be $true
+        Assert-MockCalled Invoke-WingetSourceProbe -Times 1 -Exactly
+        Assert-MockCalled Repair-WinGetPackageManager -Times 0 -Exactly
+    }
+
+    It 'Repairs the package manager and succeeds when the re-probe passes' {
+        $script:probeCallCount = 0
+        Mock Invoke-WingetSourceProbe {
+            $script:probeCallCount++
+            if ($script:probeCallCount -eq 1) {
+                # First probe: blocked per-user bootstrap (0x80073D19).
+                return @{ Succeeded = $false; ExitCode = -2147009255; TimedOut = $false }
+            }
+            return @{ Succeeded = $true; ExitCode = 0; TimedOut = $false }
+        }
+
+        $result = Initialize-WingetSourcesForUser
+
+        $result | Should -Be $true
+        Assert-MockCalled Repair-WinGetPackageManager -Times 1 -Exactly
+        Assert-MockCalled Invoke-WingetSourceProbe -Times 2 -Exactly
+    }
+
+    It 'Returns false when the probe still fails after repair' {
+        Mock Invoke-WingetSourceProbe { @{ Succeeded = $false; ExitCode = -2147009255; TimedOut = $false } }
+
+        $result = Initialize-WingetSourcesForUser
+
+        $result | Should -Be $false
+        Assert-MockCalled Repair-WinGetPackageManager -Times 1 -Exactly
+        Assert-MockCalled Invoke-WingetSourceProbe -Times 2 -Exactly
+    }
+
+    It 'Returns false and skips repair when Repair-WinGetPackageManager is unavailable' {
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'Repair-WinGetPackageManager' }
+        Mock Invoke-WingetSourceProbe { @{ Succeeded = $false; ExitCode = -1978335162; TimedOut = $false } }
+
+        $result = Initialize-WingetSourcesForUser
+
+        $result | Should -Be $false
+        Assert-MockCalled Repair-WinGetPackageManager -Times 0 -Exactly
+        Assert-MockCalled Invoke-WingetSourceProbe -Times 1 -Exactly
+    }
+
+    It 'Warns about cross-user elevation when the process account differs from the session owner' {
+        Mock Get-ProcessUserName { 'CONTOSO\admin-jmaffiola' }
+        Mock Get-InteractiveSessionUserName { 'CONTOSO\jdoe' }
+        Mock Invoke-WingetSourceProbe { @{ Succeeded = $true; ExitCode = 0; TimedOut = $false } }
+
+        [void](Initialize-WingetSourcesForUser)
+
+        Assert-MockCalled Write-WarningMessage -Times 1 -ParameterFilter { $Message -match 'Cross-user elevation detected' }
+    }
+
+    It 'Does not warn about cross-user elevation for a same-account session' {
+        Mock Invoke-WingetSourceProbe { @{ Succeeded = $true; ExitCode = 0; TimedOut = $false } }
+
+        [void](Initialize-WingetSourcesForUser)
+
+        Assert-MockCalled Write-WarningMessage -Times 0 -ParameterFilter { $Message -match 'Cross-user elevation detected' }
+    }
 }
 
 Describe 'App list consistency' {

--- a/Test-WingetAppInstall.Tests.ps1
+++ b/Test-WingetAppInstall.Tests.ps1
@@ -1824,6 +1824,8 @@ Describe 'Invoke-WingetSourceProbe' {
         Assert-MockCalled Start-Process -Times 1 -Exactly -ParameterFilter {
             ($ArgumentList -contains 'source') -and
             ($ArgumentList -contains 'update') -and
+            ($ArgumentList -contains '--name') -and
+            ($ArgumentList -contains 'winget') -and
             ($ArgumentList -contains '--accept-source-agreements') -and
             ($ArgumentList -contains '--disable-interactivity')
         }

--- a/WingetAppSetup/Private/Elevation.ps1
+++ b/WingetAppSetup/Private/Elevation.ps1
@@ -25,6 +25,43 @@ function Test-IsRunningLocally {
 
 <#
 .SYNOPSIS
+    Returns the account name the current process is running as (DOMAIN\user), or $null.
+#>
+function Get-ProcessUserName {
+    try {
+        return [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    }
+    catch {
+        return $null
+    }
+}
+
+<#
+.SYNOPSIS
+    Returns the account name that owns the interactive console session (DOMAIN\user), or $null.
+.DESCRIPTION
+    Win32_ComputerSystem.UserName reports the interactively logged-on console user regardless of
+    which account the current (possibly elevated) process runs as. Comparing it with
+    Get-ProcessUserName detects cross-user elevation — running elevated as a different account
+    than the logged-on user — where winget's per-user MSIX bootstrap is blocked by the AppX
+    deployment service with 0x80073D19 because the process account has no interactive logon
+    session (issue #159).
+#>
+function Get-InteractiveSessionUserName {
+    try {
+        $userName = (Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop).UserName
+        if ([string]::IsNullOrWhiteSpace($userName)) {
+            return $null
+        }
+        return $userName
+    }
+    catch {
+        return $null
+    }
+}
+
+<#
+.SYNOPSIS
     Relaunches the script with elevated privileges, preferring Windows Terminal when available.
 .DESCRIPTION
     Attempts to restart the current script in an elevated session. When Windows Terminal is installed,

--- a/WingetAppSetup/Private/WingetBootstrap.ps1
+++ b/WingetAppSetup/Private/WingetBootstrap.ps1
@@ -1,0 +1,51 @@
+<#
+.SYNOPSIS
+    Opens and updates winget sources for the current account, accepting source agreements.
+.DESCRIPTION
+    Runs `winget source update --accept-source-agreements --disable-interactivity` under a timeout
+    guard. This is the lightest command that forces winget's per-user first-use bootstrap: it
+    registers the Microsoft.Winget.Source package for the invoking account and persists source
+    agreement acceptance in that account's winget state (acceptance is saved per-user; see
+    microsoft/winget-cli SourceList.cpp). Exit code 0 therefore means the account is fully
+    initialized for unattended installs.
+.PARAMETER TimeoutSeconds
+    Maximum seconds to wait for winget before killing the process. Default 120.
+.RETURNS
+    [hashtable] @{ Succeeded = <bool>; ExitCode = <int or $null>; TimedOut = <bool> }
+    ExitCode is $null when the process timed out or failed to start.
+#>
+function Invoke-WingetSourceProbe {
+    param (
+        [Parameter(Mandatory = $false)]
+        [int]$TimeoutSeconds = 120
+    )
+
+    try {
+        $probeProcess = Start-Process -FilePath 'winget' `
+            -ArgumentList 'source', 'update', '--accept-source-agreements', '--disable-interactivity' `
+            -NoNewWindow `
+            -PassThru `
+            -RedirectStandardOutput "$env:TEMP\winget_source_probe_output.txt" `
+            -RedirectStandardError "$env:TEMP\winget_source_probe_error.txt"
+
+        if (-not $probeProcess.WaitForExit($TimeoutSeconds * 1000)) {
+            Write-WarningMessage "Winget source update timed out after $TimeoutSeconds seconds. Terminating process..."
+            try { $probeProcess.Kill() } catch { }
+            return @{ Succeeded = $false; ExitCode = $null; TimedOut = $true }
+        }
+
+        return @{
+            Succeeded = ($probeProcess.ExitCode -eq 0)
+            ExitCode  = $probeProcess.ExitCode
+            TimedOut  = $false
+        }
+    }
+    catch {
+        Write-WarningMessage "Winget source update failed to run: $_"
+        return @{ Succeeded = $false; ExitCode = $null; TimedOut = $false }
+    }
+    finally {
+        Remove-Item "$env:TEMP\winget_source_probe_output.txt" -ErrorAction SilentlyContinue
+        Remove-Item "$env:TEMP\winget_source_probe_error.txt" -ErrorAction SilentlyContinue
+    }
+}

--- a/WingetAppSetup/Private/WingetBootstrap.ps1
+++ b/WingetAppSetup/Private/WingetBootstrap.ps1
@@ -1,13 +1,19 @@
 <#
 .SYNOPSIS
-    Opens and updates winget sources for the current account, accepting source agreements.
+    Opens and updates the winget source for the current account, accepting source agreements.
 .DESCRIPTION
-    Runs `winget source update --accept-source-agreements --disable-interactivity` under a timeout
-    guard. This is the lightest command that forces winget's per-user first-use bootstrap: it
-    registers the Microsoft.Winget.Source package for the invoking account and persists source
-    agreement acceptance in that account's winget state (acceptance is saved per-user; see
-    microsoft/winget-cli SourceList.cpp). Exit code 0 therefore means the account is fully
-    initialized for unattended installs.
+    Runs `winget source update --name winget --accept-source-agreements --disable-interactivity`
+    under a timeout guard. This is the lightest command that forces winget's per-user first-use
+    bootstrap: it registers the Microsoft.Winget.Source package for the invoking account and
+    persists source agreement acceptance in that account's winget state (acceptance is saved
+    per-user; see microsoft/winget-cli SourceList.cpp). Exit code 0 therefore means the account is
+    initialized for unattended installs from the winget source — the only source the install
+    phase uses (`--source winget`).
+
+    The probe is deliberately scoped to the winget source: msstore can fail for an account that
+    has never logged on interactively even when the winget source is healthy
+    (microsoft/winget-cli#5398/#6334), and probing it would report a false failure for the only
+    source that matters here.
 .PARAMETER TimeoutSeconds
     Maximum seconds to wait for winget before killing the process. Default 120.
 .RETURNS
@@ -22,7 +28,7 @@ function Invoke-WingetSourceProbe {
 
     try {
         $probeProcess = Start-Process -FilePath 'winget' `
-            -ArgumentList 'source', 'update', '--accept-source-agreements', '--disable-interactivity' `
+            -ArgumentList 'source', 'update', '--name', 'winget', '--accept-source-agreements', '--disable-interactivity' `
             -NoNewWindow `
             -PassThru `
             -RedirectStandardOutput "$env:TEMP\winget_source_probe_output.txt" `

--- a/WingetAppSetup/Public/Install.ps1
+++ b/WingetAppSetup/Public/Install.ps1
@@ -70,16 +70,11 @@ function Invoke-WingetInstall {
         Write-Success 'Starting...'
     }
 
-    # Initialize winget sources in user context to prevent session errors (issue #104)
-    [void](Initialize-WingetSourcesForUser -WhatIf:$WhatIf)
-
-    # Ensure required modules are available
+    # Ensure the WinGet PowerShell module is available before touching winget itself:
+    # Test-AndInstallWinget and Initialize-WingetSourcesForUser use Repair-WinGetPackageManager
+    # to bootstrap winget for accounts that have no interactive logon session (issue #159).
     if (-not (Test-AndInstallWingetModule)) {
         Write-Warning 'Microsoft.WinGet.Client module is not available. Update functionality will use fallback CLI methods.'
-    }
-
-    if (-not (Test-AndInstallGraphicalTools)) {
-        Write-Warning 'Out-GridView will be unavailable; results will be displayed in text mode only.'
     }
 
     # Import required modules
@@ -96,6 +91,15 @@ function Invoke-WingetInstall {
     if (-not (Test-AndInstallWinget)) {
         Write-ErrorMessage 'Winget is required for this script. Exiting.'
         Exit
+    }
+
+    # Initialize winget sources and agreements for the account performing the installs. This is
+    # what prevents 0x80073d19 when the script is elevated as a different account than the
+    # logged-on user (issues #104/#150, #159).
+    [void](Initialize-WingetSourcesForUser -WhatIf:$WhatIf)
+
+    if (-not (Test-AndInstallGraphicalTools)) {
+        Write-Warning 'Out-GridView will be unavailable; results will be displayed in text mode only.'
     }
 
     # Verify winget sources are accessible and auto-repair if broken

--- a/WingetAppSetup/Public/WingetCore.ps1
+++ b/WingetAppSetup/Public/WingetCore.ps1
@@ -56,6 +56,25 @@ function Test-AndInstallWinget {
         return $true
     }
     else {
+        # Prefer Repair-WinGetPackageManager when the WinGet PowerShell module is available: it
+        # registers the App Installer package for the current account even without an interactive
+        # logon session, where a plain Add-AppxPackage is blocked with 0x80073D19
+        # (microsoft/winget-cli#3862, issue #159).
+        if (Get-Command Repair-WinGetPackageManager -ErrorAction SilentlyContinue) {
+            Write-WarningMessage 'Winget is not available. Bootstrapping it via Repair-WinGetPackageManager...'
+            try {
+                Repair-WinGetPackageManager -Latest -Force -ErrorAction Stop
+                if (Get-Command winget -ErrorAction SilentlyContinue) {
+                    Write-Success 'Winget bootstrapped successfully via Repair-WinGetPackageManager.'
+                    return $true
+                }
+                Write-WarningMessage 'Repair-WinGetPackageManager completed but winget is still unavailable. Falling back to App Installer download...'
+            }
+            catch {
+                Write-WarningMessage "Repair-WinGetPackageManager failed: $_. Falling back to App Installer download..."
+            }
+        }
+
         Write-WarningMessage 'Winget is not available. Attempting to install Microsoft App Installer...'
         try {
             $url = 'https://aka.ms/getwinget'
@@ -487,15 +506,26 @@ function Get-UpdateReport {
 
 <#
 .SYNOPSIS
-    Initializes winget sources in the current user context to prevent session errors.
+    Initializes winget sources and agreements for the account performing the installs.
 .DESCRIPTION
-    Runs a lightweight winget command in user context (without elevation) to ensure source
-    agreements are accepted by the current user. This prevents 0x80073d19 errors that occur
-    when the script runs as admin but winget sources haven't been initialized for the user.
+    Winget state — source registration and agreement acceptance — is per-user. When the script is
+    elevated as a different account than the interactively logged-on user (e.g. an admin-* account
+    entered at the UAC prompt), that account has no interactive logon session, and winget's
+    first-use bootstrap (registering the Microsoft.Winget.Source MSIX package for the account) is
+    blocked by the AppX deployment service with 0x80073D19
+    (ERROR_DEPLOYMENT_BLOCKED_BY_USER_LOG_OFF). Every install then fails, and no amount of
+    retrying helps because the missing per-user state is persistent (issues #81/#104/#150, #159).
+
+    This function probes with `winget source update --accept-source-agreements` (which both forces
+    the bootstrap and persists agreement acceptance for the account). When the probe fails, it
+    bootstraps winget for the account via Repair-WinGetPackageManager — which registers the App
+    Installer and Microsoft.Winget.Source packages even without an interactive logon session
+    (microsoft/winget-cli#6334) — and probes again.
 .PARAMETER WhatIf
     When specified, only reports intended actions without executing.
 .RETURNS
-    [bool] True if initialization succeeded or was already done, False if an error occurred.
+    [bool] True when sources are initialized and agreements accepted for the current account,
+    otherwise False.
 #>
 function Initialize-WingetSourcesForUser {
     param (
@@ -504,50 +534,68 @@ function Initialize-WingetSourcesForUser {
     )
 
     if ($WhatIf) {
-        Write-Info '[DRY-RUN] Would initialize winget sources for current user'
+        Write-Info '[DRY-RUN] Would initialize winget sources and agreements for the current account'
         return $true
     }
 
-    Write-Info 'Initializing winget sources for current user context...'
-    Write-Info 'You may be prompted to accept source agreements.'
+    # 0x80073D19 (ERROR_DEPLOYMENT_BLOCKED_BY_USER_LOG_OFF) as a signed Int32.
+    $deploymentBlockedExitCode = -2147009255
+    # 0x8A150046 (APPINSTALLER_CLI_ERROR_SOURCE_AGREEMENTS_NOT_ACCEPTED) as a signed Int32.
+    $agreementsNotAcceptedExitCode = -1978335162
 
-    try {
-        $output = & winget list --disable-interactivity 2>&1
-        $exitCode = $LASTEXITCODE
+    $processUser = Get-ProcessUserName
+    $sessionUser = Get-InteractiveSessionUserName
+    $isCrossUserElevation = ($processUser -and $sessionUser -and ($processUser -ne $sessionUser))
+    if ($isCrossUserElevation) {
+        Write-WarningMessage "Cross-user elevation detected: running as '$processUser' while '$sessionUser' owns the interactive session."
+        Write-WarningMessage "Winget sources and agreements are per-user; initializing them for '$processUser'."
+    }
 
-        if ($exitCode -eq 0) {
-            Write-Success 'Winget sources initialized successfully for user context.'
+    Write-Info 'Initializing winget sources for the current account (this may take a moment)...'
+    $probe = Invoke-WingetSourceProbe
+    if ($probe.Succeeded) {
+        Write-Success 'Winget sources are initialized and agreements accepted for this account.'
+        return $true
+    }
+
+    if ($probe.ExitCode -eq $deploymentBlockedExitCode) {
+        Write-WarningMessage 'Winget source bootstrap was blocked by the AppX deployment service (0x80073D19): this account has no interactive logon session.'
+    }
+    elseif ($probe.ExitCode -eq $agreementsNotAcceptedExitCode) {
+        Write-WarningMessage 'Winget source agreements are not yet accepted for this account (0x8A150046).'
+    }
+    elseif ($null -ne $probe.ExitCode) {
+        Write-WarningMessage "Winget source update failed with exit code: $($probe.ExitCode)"
+    }
+
+    # Bootstrap via the WinGet PowerShell module: unlike winget's own first-use bootstrap (and
+    # unlike a plain Add-AppxPackage), Repair-WinGetPackageManager registers the App Installer and
+    # Microsoft.Winget.Source packages for the current account even without an interactive logon
+    # session (microsoft/winget-cli#6334).
+    if (Get-Command Repair-WinGetPackageManager -ErrorAction SilentlyContinue) {
+        Write-Info 'Bootstrapping winget for this account via Repair-WinGetPackageManager...'
+        try {
+            Repair-WinGetPackageManager -Latest -Force -ErrorAction Stop
+        }
+        catch {
+            Write-WarningMessage "Repair-WinGetPackageManager failed: $_"
+        }
+
+        $probe = Invoke-WingetSourceProbe
+        if ($probe.Succeeded) {
+            Write-Success 'Winget sources initialized for this account after repair.'
             return $true
         }
-
-        # Exit code -1 with "source agreements not accepted" is actually expected the first time
-        # and means the user can now accept them. The next execution will work.
-        if ($exitCode -eq -1 -and $output -match 'source agreement|You must accept') {
-            Write-Info 'Source agreements need to be accepted. Running interactive prompt...'
-            # Run again without --disable-interactivity to allow user interaction
-            $output = & winget list 2>&1
-            $exitCode = $LASTEXITCODE
-
-            if ($exitCode -eq 0) {
-                Write-Success 'Source agreements accepted. Winget is ready to use.'
-                return $true
-            }
-        }
-
-        if ($exitCode -eq 0) {
-            Write-Success 'Winget sources are accessible.'
-            return $true
-        }
-
-        Write-WarningMessage "Winget source initialization returned exit code: $exitCode"
-        Write-WarningMessage 'Continuing with installation; retry logic will handle any session errors.'
-        return $true
     }
-    catch {
-        Write-WarningMessage "Error initializing winget sources: $_"
-        Write-WarningMessage 'Continuing with installation; retry logic will handle any session errors.'
-        return $true
+    else {
+        Write-WarningMessage 'Repair-WinGetPackageManager is unavailable (Microsoft.WinGet.Client module missing); skipping winget bootstrap repair.'
     }
+
+    Write-WarningMessage "Winget sources could not be initialized for '$processUser'. Installations may fail with 0x80073D19."
+    if ($isCrossUserElevation) {
+        Write-WarningMessage "Fix: log on to Windows interactively as '$processUser' once (this registers winget for that account), or run 'winget source update' from any session running as '$processUser', then re-run this script."
+    }
+    return $false
 }
 
 <#
@@ -565,6 +613,13 @@ function Initialize-WingetSourcesForUser {
     winget's output is intentionally left unredirected so its native progress is still shown to the
     user; the session error is identified purely from the exit code, which winget reports as
     0x80073d19 for this failure.
+
+    Installs prefer `--scope machine` (issue #159): user-scope installs land in the elevated
+    account's profile rather than the logged-on user's, and packages that ship both MSIX and MSI
+    installers (e.g. Microsoft.PowerShell) resolve at user scope to the MSIX — whose per-user AppX
+    deployment is exactly what 0x80073D19 blocks under cross-user elevation. When a package has no
+    machine-scope installer (e.g. the MSIX-only Microsoft.WindowsTerminal), winget returns
+    0x8A150010 (NO_APPLICABLE_INSTALLER) and the install is retried once at winget's default scope.
 .PARAMETER PackageId
     The winget package id to install (e.g. 'Microsoft.PowerShell').
 .PARAMETER MaxAttempts
@@ -572,8 +627,11 @@ function Initialize-WingetSourcesForUser {
 .PARAMETER InitialDelaySeconds
     Seconds to wait before the first retry; the wait doubles on each subsequent retry. Default 5.
 .RETURNS
-    [hashtable] @{ ExitCode = <int>; Attempts = <int>; SessionErrorExhausted = <bool> }
+    [hashtable] @{ ExitCode = <int>; Attempts = <int>; SessionErrorExhausted = <bool>; MachineScopeFellBack = <bool> }
     SessionErrorExhausted is True only when every attempt failed with the session error.
+    MachineScopeFellBack is True when the package had no machine-scope installer and the install
+    was retried at winget's default scope. Attempts counts install attempts at the finally
+    selected scope; the one-time scope fallback does not consume a session-error attempt.
 #>
 function Install-WingetPackage {
     param (
@@ -587,13 +645,18 @@ function Install-WingetPackage {
         [int]$InitialDelaySeconds = 5
     )
 
-    # 0x80073D19 (ERROR_INSTALL_USER_LOGOFF) as a signed Int32, which is how winget reports it
-    # through Process.ExitCode.
+    # 0x80073D19 (ERROR_DEPLOYMENT_BLOCKED_BY_USER_LOG_OFF) as a signed Int32, which is how winget
+    # reports it through Process.ExitCode.
     $sessionLogoffExitCode = -2147009255
+    # 0x8A150010 (APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER) as a signed Int32: returned when
+    # the --scope machine requirement filters out every installer in the package's manifest.
+    $noApplicableInstallerExitCode = -1978335216
 
     $attempt = 0
     $delay = $InitialDelaySeconds
     $exitCode = 0
+    $useMachineScope = $true
+    $machineScopeFellBack = $false
 
     while ($attempt -lt $MaxAttempts) {
         $attempt++
@@ -604,9 +667,24 @@ function Install-WingetPackage {
             '--source', 'winget',
             '--id', $PackageId
         )
+        if ($useMachineScope) {
+            $installArgs += @('--scope', 'machine')
+        }
 
         $proc = Start-Process -FilePath 'winget' -ArgumentList $installArgs -NoNewWindow -Wait -PassThru
         $exitCode = $proc.ExitCode
+
+        # No installer matched the machine-scope requirement (e.g. MSIX-only packages such as
+        # Microsoft.WindowsTerminal, which only install per-user). Fall back to winget's default
+        # scope once; this is a manifest property, not a transient error, so it does not consume
+        # one of the session-error attempts.
+        if ($useMachineScope -and $exitCode -eq $noApplicableInstallerExitCode) {
+            Write-Info "$PackageId has no machine-scope installer. Retrying with winget's default scope..."
+            $useMachineScope = $false
+            $machineScopeFellBack = $true
+            $attempt--
+            continue
+        }
 
         # Anything other than the transient session error (success or a real failure) is final here;
         # the caller verifies the actual install state with `winget list`.
@@ -628,6 +706,7 @@ function Install-WingetPackage {
         ExitCode              = $exitCode
         Attempts              = $attempt
         SessionErrorExhausted = ($exitCode -eq $sessionLogoffExitCode)
+        MachineScopeFellBack  = $machineScopeFellBack
     }
 }
 

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -97,6 +97,43 @@ function Test-IsRunningLocally {
 
 <#
 .SYNOPSIS
+    Returns the account name the current process is running as (DOMAIN\user), or $null.
+#>
+function Get-ProcessUserName {
+    try {
+        return [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    }
+    catch {
+        return $null
+    }
+}
+
+<#
+.SYNOPSIS
+    Returns the account name that owns the interactive console session (DOMAIN\user), or $null.
+.DESCRIPTION
+    Win32_ComputerSystem.UserName reports the interactively logged-on console user regardless of
+    which account the current (possibly elevated) process runs as. Comparing it with
+    Get-ProcessUserName detects cross-user elevation — running elevated as a different account
+    than the logged-on user — where winget's per-user MSIX bootstrap is blocked by the AppX
+    deployment service with 0x80073D19 because the process account has no interactive logon
+    session (issue #159).
+#>
+function Get-InteractiveSessionUserName {
+    try {
+        $userName = (Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop).UserName
+        if ([string]::IsNullOrWhiteSpace($userName)) {
+            return $null
+        }
+        return $userName
+    }
+    catch {
+        return $null
+    }
+}
+
+<#
+.SYNOPSIS
     Relaunches the script with elevated privileges, preferring Windows Terminal when available.
 .DESCRIPTION
     Attempts to restart the current script in an elevated session. When Windows Terminal is installed,
@@ -373,6 +410,59 @@ function Test-AndInstallGraphicalTools {
     return $false
 }
 
+# --- WingetBootstrap ---
+<#
+.SYNOPSIS
+    Opens and updates winget sources for the current account, accepting source agreements.
+.DESCRIPTION
+    Runs `winget source update --accept-source-agreements --disable-interactivity` under a timeout
+    guard. This is the lightest command that forces winget's per-user first-use bootstrap: it
+    registers the Microsoft.Winget.Source package for the invoking account and persists source
+    agreement acceptance in that account's winget state (acceptance is saved per-user; see
+    microsoft/winget-cli SourceList.cpp). Exit code 0 therefore means the account is fully
+    initialized for unattended installs.
+.PARAMETER TimeoutSeconds
+    Maximum seconds to wait for winget before killing the process. Default 120.
+.RETURNS
+    [hashtable] @{ Succeeded = <bool>; ExitCode = <int or $null>; TimedOut = <bool> }
+    ExitCode is $null when the process timed out or failed to start.
+#>
+function Invoke-WingetSourceProbe {
+    param (
+        [Parameter(Mandatory = $false)]
+        [int]$TimeoutSeconds = 120
+    )
+
+    try {
+        $probeProcess = Start-Process -FilePath 'winget' `
+            -ArgumentList 'source', 'update', '--accept-source-agreements', '--disable-interactivity' `
+            -NoNewWindow `
+            -PassThru `
+            -RedirectStandardOutput "$env:TEMP\winget_source_probe_output.txt" `
+            -RedirectStandardError "$env:TEMP\winget_source_probe_error.txt"
+
+        if (-not $probeProcess.WaitForExit($TimeoutSeconds * 1000)) {
+            Write-WarningMessage "Winget source update timed out after $TimeoutSeconds seconds. Terminating process..."
+            try { $probeProcess.Kill() } catch { }
+            return @{ Succeeded = $false; ExitCode = $null; TimedOut = $true }
+        }
+
+        return @{
+            Succeeded = ($probeProcess.ExitCode -eq 0)
+            ExitCode  = $probeProcess.ExitCode
+            TimedOut  = $false
+        }
+    }
+    catch {
+        Write-WarningMessage "Winget source update failed to run: $_"
+        return @{ Succeeded = $false; ExitCode = $null; TimedOut = $false }
+    }
+    finally {
+        Remove-Item "$env:TEMP\winget_source_probe_output.txt" -ErrorAction SilentlyContinue
+        Remove-Item "$env:TEMP\winget_source_probe_error.txt" -ErrorAction SilentlyContinue
+    }
+}
+
 # --- WingetUpgrade ---
 <#
 .SYNOPSIS
@@ -563,16 +653,11 @@ function Invoke-WingetInstall {
         Write-Success 'Starting...'
     }
 
-    # Initialize winget sources in user context to prevent session errors (issue #104)
-    [void](Initialize-WingetSourcesForUser -WhatIf:$WhatIf)
-
-    # Ensure required modules are available
+    # Ensure the WinGet PowerShell module is available before touching winget itself:
+    # Test-AndInstallWinget and Initialize-WingetSourcesForUser use Repair-WinGetPackageManager
+    # to bootstrap winget for accounts that have no interactive logon session (issue #159).
     if (-not (Test-AndInstallWingetModule)) {
         Write-Warning 'Microsoft.WinGet.Client module is not available. Update functionality will use fallback CLI methods.'
-    }
-
-    if (-not (Test-AndInstallGraphicalTools)) {
-        Write-Warning 'Out-GridView will be unavailable; results will be displayed in text mode only.'
     }
 
     # Import required modules
@@ -589,6 +674,15 @@ function Invoke-WingetInstall {
     if (-not (Test-AndInstallWinget)) {
         Write-ErrorMessage 'Winget is required for this script. Exiting.'
         Exit
+    }
+
+    # Initialize winget sources and agreements for the account performing the installs. This is
+    # what prevents 0x80073d19 when the script is elevated as a different account than the
+    # logged-on user (issues #104/#150, #159).
+    [void](Initialize-WingetSourcesForUser -WhatIf:$WhatIf)
+
+    if (-not (Test-AndInstallGraphicalTools)) {
+        Write-Warning 'Out-GridView will be unavailable; results will be displayed in text mode only.'
     }
 
     # Verify winget sources are accessible and auto-repair if broken
@@ -1854,6 +1948,25 @@ function Test-AndInstallWinget {
         return $true
     }
     else {
+        # Prefer Repair-WinGetPackageManager when the WinGet PowerShell module is available: it
+        # registers the App Installer package for the current account even without an interactive
+        # logon session, where a plain Add-AppxPackage is blocked with 0x80073D19
+        # (microsoft/winget-cli#3862, issue #159).
+        if (Get-Command Repair-WinGetPackageManager -ErrorAction SilentlyContinue) {
+            Write-WarningMessage 'Winget is not available. Bootstrapping it via Repair-WinGetPackageManager...'
+            try {
+                Repair-WinGetPackageManager -Latest -Force -ErrorAction Stop
+                if (Get-Command winget -ErrorAction SilentlyContinue) {
+                    Write-Success 'Winget bootstrapped successfully via Repair-WinGetPackageManager.'
+                    return $true
+                }
+                Write-WarningMessage 'Repair-WinGetPackageManager completed but winget is still unavailable. Falling back to App Installer download...'
+            }
+            catch {
+                Write-WarningMessage "Repair-WinGetPackageManager failed: $_. Falling back to App Installer download..."
+            }
+        }
+
         Write-WarningMessage 'Winget is not available. Attempting to install Microsoft App Installer...'
         try {
             $url = 'https://aka.ms/getwinget'
@@ -2285,15 +2398,26 @@ function Get-UpdateReport {
 
 <#
 .SYNOPSIS
-    Initializes winget sources in the current user context to prevent session errors.
+    Initializes winget sources and agreements for the account performing the installs.
 .DESCRIPTION
-    Runs a lightweight winget command in user context (without elevation) to ensure source
-    agreements are accepted by the current user. This prevents 0x80073d19 errors that occur
-    when the script runs as admin but winget sources haven't been initialized for the user.
+    Winget state — source registration and agreement acceptance — is per-user. When the script is
+    elevated as a different account than the interactively logged-on user (e.g. an admin-* account
+    entered at the UAC prompt), that account has no interactive logon session, and winget's
+    first-use bootstrap (registering the Microsoft.Winget.Source MSIX package for the account) is
+    blocked by the AppX deployment service with 0x80073D19
+    (ERROR_DEPLOYMENT_BLOCKED_BY_USER_LOG_OFF). Every install then fails, and no amount of
+    retrying helps because the missing per-user state is persistent (issues #81/#104/#150, #159).
+
+    This function probes with `winget source update --accept-source-agreements` (which both forces
+    the bootstrap and persists agreement acceptance for the account). When the probe fails, it
+    bootstraps winget for the account via Repair-WinGetPackageManager — which registers the App
+    Installer and Microsoft.Winget.Source packages even without an interactive logon session
+    (microsoft/winget-cli#6334) — and probes again.
 .PARAMETER WhatIf
     When specified, only reports intended actions without executing.
 .RETURNS
-    [bool] True if initialization succeeded or was already done, False if an error occurred.
+    [bool] True when sources are initialized and agreements accepted for the current account,
+    otherwise False.
 #>
 function Initialize-WingetSourcesForUser {
     param (
@@ -2302,50 +2426,68 @@ function Initialize-WingetSourcesForUser {
     )
 
     if ($WhatIf) {
-        Write-Info '[DRY-RUN] Would initialize winget sources for current user'
+        Write-Info '[DRY-RUN] Would initialize winget sources and agreements for the current account'
         return $true
     }
 
-    Write-Info 'Initializing winget sources for current user context...'
-    Write-Info 'You may be prompted to accept source agreements.'
+    # 0x80073D19 (ERROR_DEPLOYMENT_BLOCKED_BY_USER_LOG_OFF) as a signed Int32.
+    $deploymentBlockedExitCode = -2147009255
+    # 0x8A150046 (APPINSTALLER_CLI_ERROR_SOURCE_AGREEMENTS_NOT_ACCEPTED) as a signed Int32.
+    $agreementsNotAcceptedExitCode = -1978335162
 
-    try {
-        $output = & winget list --disable-interactivity 2>&1
-        $exitCode = $LASTEXITCODE
+    $processUser = Get-ProcessUserName
+    $sessionUser = Get-InteractiveSessionUserName
+    $isCrossUserElevation = ($processUser -and $sessionUser -and ($processUser -ne $sessionUser))
+    if ($isCrossUserElevation) {
+        Write-WarningMessage "Cross-user elevation detected: running as '$processUser' while '$sessionUser' owns the interactive session."
+        Write-WarningMessage "Winget sources and agreements are per-user; initializing them for '$processUser'."
+    }
 
-        if ($exitCode -eq 0) {
-            Write-Success 'Winget sources initialized successfully for user context.'
+    Write-Info 'Initializing winget sources for the current account (this may take a moment)...'
+    $probe = Invoke-WingetSourceProbe
+    if ($probe.Succeeded) {
+        Write-Success 'Winget sources are initialized and agreements accepted for this account.'
+        return $true
+    }
+
+    if ($probe.ExitCode -eq $deploymentBlockedExitCode) {
+        Write-WarningMessage 'Winget source bootstrap was blocked by the AppX deployment service (0x80073D19): this account has no interactive logon session.'
+    }
+    elseif ($probe.ExitCode -eq $agreementsNotAcceptedExitCode) {
+        Write-WarningMessage 'Winget source agreements are not yet accepted for this account (0x8A150046).'
+    }
+    elseif ($null -ne $probe.ExitCode) {
+        Write-WarningMessage "Winget source update failed with exit code: $($probe.ExitCode)"
+    }
+
+    # Bootstrap via the WinGet PowerShell module: unlike winget's own first-use bootstrap (and
+    # unlike a plain Add-AppxPackage), Repair-WinGetPackageManager registers the App Installer and
+    # Microsoft.Winget.Source packages for the current account even without an interactive logon
+    # session (microsoft/winget-cli#6334).
+    if (Get-Command Repair-WinGetPackageManager -ErrorAction SilentlyContinue) {
+        Write-Info 'Bootstrapping winget for this account via Repair-WinGetPackageManager...'
+        try {
+            Repair-WinGetPackageManager -Latest -Force -ErrorAction Stop
+        }
+        catch {
+            Write-WarningMessage "Repair-WinGetPackageManager failed: $_"
+        }
+
+        $probe = Invoke-WingetSourceProbe
+        if ($probe.Succeeded) {
+            Write-Success 'Winget sources initialized for this account after repair.'
             return $true
         }
-
-        # Exit code -1 with "source agreements not accepted" is actually expected the first time
-        # and means the user can now accept them. The next execution will work.
-        if ($exitCode -eq -1 -and $output -match 'source agreement|You must accept') {
-            Write-Info 'Source agreements need to be accepted. Running interactive prompt...'
-            # Run again without --disable-interactivity to allow user interaction
-            $output = & winget list 2>&1
-            $exitCode = $LASTEXITCODE
-
-            if ($exitCode -eq 0) {
-                Write-Success 'Source agreements accepted. Winget is ready to use.'
-                return $true
-            }
-        }
-
-        if ($exitCode -eq 0) {
-            Write-Success 'Winget sources are accessible.'
-            return $true
-        }
-
-        Write-WarningMessage "Winget source initialization returned exit code: $exitCode"
-        Write-WarningMessage 'Continuing with installation; retry logic will handle any session errors.'
-        return $true
     }
-    catch {
-        Write-WarningMessage "Error initializing winget sources: $_"
-        Write-WarningMessage 'Continuing with installation; retry logic will handle any session errors.'
-        return $true
+    else {
+        Write-WarningMessage 'Repair-WinGetPackageManager is unavailable (Microsoft.WinGet.Client module missing); skipping winget bootstrap repair.'
     }
+
+    Write-WarningMessage "Winget sources could not be initialized for '$processUser'. Installations may fail with 0x80073D19."
+    if ($isCrossUserElevation) {
+        Write-WarningMessage "Fix: log on to Windows interactively as '$processUser' once (this registers winget for that account), or run 'winget source update' from any session running as '$processUser', then re-run this script."
+    }
+    return $false
 }
 
 <#
@@ -2363,6 +2505,13 @@ function Initialize-WingetSourcesForUser {
     winget's output is intentionally left unredirected so its native progress is still shown to the
     user; the session error is identified purely from the exit code, which winget reports as
     0x80073d19 for this failure.
+
+    Installs prefer `--scope machine` (issue #159): user-scope installs land in the elevated
+    account's profile rather than the logged-on user's, and packages that ship both MSIX and MSI
+    installers (e.g. Microsoft.PowerShell) resolve at user scope to the MSIX — whose per-user AppX
+    deployment is exactly what 0x80073D19 blocks under cross-user elevation. When a package has no
+    machine-scope installer (e.g. the MSIX-only Microsoft.WindowsTerminal), winget returns
+    0x8A150010 (NO_APPLICABLE_INSTALLER) and the install is retried once at winget's default scope.
 .PARAMETER PackageId
     The winget package id to install (e.g. 'Microsoft.PowerShell').
 .PARAMETER MaxAttempts
@@ -2370,8 +2519,11 @@ function Initialize-WingetSourcesForUser {
 .PARAMETER InitialDelaySeconds
     Seconds to wait before the first retry; the wait doubles on each subsequent retry. Default 5.
 .RETURNS
-    [hashtable] @{ ExitCode = <int>; Attempts = <int>; SessionErrorExhausted = <bool> }
+    [hashtable] @{ ExitCode = <int>; Attempts = <int>; SessionErrorExhausted = <bool>; MachineScopeFellBack = <bool> }
     SessionErrorExhausted is True only when every attempt failed with the session error.
+    MachineScopeFellBack is True when the package had no machine-scope installer and the install
+    was retried at winget's default scope. Attempts counts install attempts at the finally
+    selected scope; the one-time scope fallback does not consume a session-error attempt.
 #>
 function Install-WingetPackage {
     param (
@@ -2385,13 +2537,18 @@ function Install-WingetPackage {
         [int]$InitialDelaySeconds = 5
     )
 
-    # 0x80073D19 (ERROR_INSTALL_USER_LOGOFF) as a signed Int32, which is how winget reports it
-    # through Process.ExitCode.
+    # 0x80073D19 (ERROR_DEPLOYMENT_BLOCKED_BY_USER_LOG_OFF) as a signed Int32, which is how winget
+    # reports it through Process.ExitCode.
     $sessionLogoffExitCode = -2147009255
+    # 0x8A150010 (APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER) as a signed Int32: returned when
+    # the --scope machine requirement filters out every installer in the package's manifest.
+    $noApplicableInstallerExitCode = -1978335216
 
     $attempt = 0
     $delay = $InitialDelaySeconds
     $exitCode = 0
+    $useMachineScope = $true
+    $machineScopeFellBack = $false
 
     while ($attempt -lt $MaxAttempts) {
         $attempt++
@@ -2402,9 +2559,24 @@ function Install-WingetPackage {
             '--source', 'winget',
             '--id', $PackageId
         )
+        if ($useMachineScope) {
+            $installArgs += @('--scope', 'machine')
+        }
 
         $proc = Start-Process -FilePath 'winget' -ArgumentList $installArgs -NoNewWindow -Wait -PassThru
         $exitCode = $proc.ExitCode
+
+        # No installer matched the machine-scope requirement (e.g. MSIX-only packages such as
+        # Microsoft.WindowsTerminal, which only install per-user). Fall back to winget's default
+        # scope once; this is a manifest property, not a transient error, so it does not consume
+        # one of the session-error attempts.
+        if ($useMachineScope -and $exitCode -eq $noApplicableInstallerExitCode) {
+            Write-Info "$PackageId has no machine-scope installer. Retrying with winget's default scope..."
+            $useMachineScope = $false
+            $machineScopeFellBack = $true
+            $attempt--
+            continue
+        }
 
         # Anything other than the transient session error (success or a real failure) is final here;
         # the caller verifies the actual install state with `winget list`.
@@ -2426,6 +2598,7 @@ function Install-WingetPackage {
         ExitCode              = $exitCode
         Attempts              = $attempt
         SessionErrorExhausted = ($exitCode -eq $sessionLogoffExitCode)
+        MachineScopeFellBack  = $machineScopeFellBack
     }
 }
 

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -413,14 +413,20 @@ function Test-AndInstallGraphicalTools {
 # --- WingetBootstrap ---
 <#
 .SYNOPSIS
-    Opens and updates winget sources for the current account, accepting source agreements.
+    Opens and updates the winget source for the current account, accepting source agreements.
 .DESCRIPTION
-    Runs `winget source update --accept-source-agreements --disable-interactivity` under a timeout
-    guard. This is the lightest command that forces winget's per-user first-use bootstrap: it
-    registers the Microsoft.Winget.Source package for the invoking account and persists source
-    agreement acceptance in that account's winget state (acceptance is saved per-user; see
-    microsoft/winget-cli SourceList.cpp). Exit code 0 therefore means the account is fully
-    initialized for unattended installs.
+    Runs `winget source update --name winget --accept-source-agreements --disable-interactivity`
+    under a timeout guard. This is the lightest command that forces winget's per-user first-use
+    bootstrap: it registers the Microsoft.Winget.Source package for the invoking account and
+    persists source agreement acceptance in that account's winget state (acceptance is saved
+    per-user; see microsoft/winget-cli SourceList.cpp). Exit code 0 therefore means the account is
+    initialized for unattended installs from the winget source — the only source the install
+    phase uses (`--source winget`).
+
+    The probe is deliberately scoped to the winget source: msstore can fail for an account that
+    has never logged on interactively even when the winget source is healthy
+    (microsoft/winget-cli#5398/#6334), and probing it would report a false failure for the only
+    source that matters here.
 .PARAMETER TimeoutSeconds
     Maximum seconds to wait for winget before killing the process. Default 120.
 .RETURNS
@@ -435,7 +441,7 @@ function Invoke-WingetSourceProbe {
 
     try {
         $probeProcess = Start-Process -FilePath 'winget' `
-            -ArgumentList 'source', 'update', '--accept-source-agreements', '--disable-interactivity' `
+            -ArgumentList 'source', 'update', '--name', 'winget', '--accept-source-agreements', '--disable-interactivity' `
             -NoNewWindow `
             -PassThru `
             -RedirectStandardOutput "$env:TEMP\winget_source_probe_output.txt" `


### PR DESCRIPTION
Fixes #159

## The problem this finally addresses

PowerShell (and sometimes **all** apps) fail with `0x80073d19` on machines where the script runs elevated as `admin-*` while a different user owns the desktop — surviving four previous fix attempts (#81 → #100/#102 retries, #104/#105 source init, #107 agreement persistence, #150 backoff).

## Root cause

`0x80073d19` = `ERROR_DEPLOYMENT_BLOCKED_BY_USER_LOG_OFF`, an **AppX deployment** error: per-user MSIX registration is blocked for an account with **no interactive logon session**. Under cross-user elevation the installing account has only a UAC/runas token, so:

1. winget's first-use bootstrap (registering `Microsoft.Winget.Source` per-user) fails → **every** install fails ([winget-cli#6334](https://github.com/microsoft/winget-cli/issues/6334), [#698](https://github.com/microsoft/winget-cli/issues/698), [#3862](https://github.com/microsoft/winget-cli/issues/3862); maintainer: "The WinGet CLI was designed for a logged in user").
2. `Microsoft.PowerShell` ships both MSIX and MSI installers; winget's default user-scope preference picks the **MSIX**, whose per-user deployment hits the same block — why PowerShell specifically kept failing.

Retries can't fix persistent missing state, which is why #150's backoff didn't end it. The old `Initialize-WingetSourcesForUser` was also a no-op: its probe omitted `--accept-source-agreements` and its fallback tested exit code `-1`, which winget never returns (real code: `0x8A150046`).

## Changes

- **`Initialize-WingetSourcesForUser` rewritten**: probes with `winget source update --accept-source-agreements --disable-interactivity` (timeout-guarded, new `Invoke-WingetSourceProbe` in `Private/WingetBootstrap.ps1`); on failure bootstraps the account via `Repair-WinGetPackageManager` (confirmed to register App Installer + `Microsoft.Winget.Source` without an interactive logon in winget-cli#6334) and re-probes; returns real status with exit-code-specific diagnostics.
- **Cross-user elevation detection**: `Get-ProcessUserName` vs `Get-InteractiveSessionUserName` (`Win32_ComputerSystem.UserName`), with clear warnings and remediation guidance when initialization still fails.
- **`Install-WingetPackage` prefers `--scope machine`**, falling back once on `0x8A150010 NO_APPLICABLE_INSTALLER` (MSIX-only packages like Windows Terminal). Also fixes a latent defect: user-scope installs were landing in the *admin* account's profile, not machine-wide. PowerShell/Chrome/7zip all ship machine-scope installers.
- **`Test-AndInstallWinget`** prefers `Repair-WinGetPackageManager` over `Add-AppxPackage` (itself blocked by `0x80073d19`, winget-cli#3862).
- **`Invoke-WingetInstall` reordered**: WinGet module → winget availability → source init, so the repair path exists when source init needs it.
- CHANGELOG / STATUS / CLAUDE.md winget notes updated; installer rebuilt (`-Check` passes).

## Testing

- 15 new Pester cases: scope preference + fallback matrix, probe success/failure/timeout/missing-winget, and first-ever coverage of `Initialize-WingetSourcesForUser` (repair flow, repair-unavailable, cross-user warning, WhatIf).
- macOS run: **100 passed / 54 failed** — failure set byte-identical to `main` baseline (85 passed / 54 failed); all 54 are the documented Windows-only environment limitations. Windows CI will exercise the full set.
- Real-world validation still needed on an affected machine (fresh `admin-*` account, user never ran winget) — see checklist below.

## Verification checklist for an affected machine

- [ ] Elevated PowerShell as `admin-*` on a user's machine where neither account has run winget
- [ ] Run the `irm | iex` one-liner — expect "Cross-user elevation detected" warning, then successful source init (possibly after a `Repair-WinGetPackageManager` pass)
- [ ] Confirm `Microsoft.PowerShell` installs (machine scope → MSI)
- [ ] Confirm `Microsoft.WindowsTerminal` falls back to default scope (may still fail per-user under cross-user elevation — MSIX-only, tracked upstream in winget-cli#2721)

🤖 Generated with [Claude Code](https://claude.com/claude-code)