### PR TITLE
docs: add specs for the 10 findings from the full-repo review

### DIFF
--- a/specs/build-guard-indirect-dispatch.md
+++ b/specs/build-guard-indirect-dispatch.md
@@ -1,0 +1,107 @@
+# Spec: Close the build's undefined-reference guard's blind spot for indirect dispatch
+
+## Goal
+`build/Build-WingetInstallScript.ps1`'s undefined-reference guard must catch a stale
+catalog-carried function name (e.g. after a rename) instead of passing silently while the generated
+installer ships broken.
+
+## Context
+`Get-UndefinedCommandReference` (`build/Build-WingetInstallScript.ps1`, lines 32-82) walks the
+assembled script's AST, collects every `CommandAst` node's `.GetCommandName()` (lines 68-71,
+filtered to hyphenated names only), and checks each resolves to a module-defined function or a real
+external command (lines 73-81).
+
+`GetCommandName()` returns `$null` for an indirect invocation — the call operator `&` applied to a
+variable/member-expression rather than a literal command name. `WingetAppSetup/Private/
+InstallVerification.ps1:107` does exactly this: `$customResult = & $App.install`. The invoked name
+is carried as **data**, not code: `WingetAppSetup/Public/AppCatalog.ps1:46` has
+`@{name = 'Microsoft.PowerShell'; install = 'Install-PowerShellLatest' }`.
+
+Reproduced empirically by an independent verifier agent (CONFIRMED, full-repo review, 2026-07-16):
+renaming `Install-PowerShellLatest` (updating its definition and the `.psd1`'s
+`FunctionsToExport` together, as a normal refactor would) while leaving the `AppCatalog.ps1` string
+stale passes the parse guard, the ASCII guard, the export guard, the undefined-reference guard, and
+`-Check` — all with zero errors. The installer only breaks at runtime, with a
+`CommandNotFoundException` the moment it tries to install that one specific app.
+`tests/AppCatalog.Tests.ps1:82` pins the catalog string against a fixed literal
+(`Should -Be 'Install-PowerShellLatest'`), which does not catch a coordinated rename (the literal
+in the test would need updating too, and nothing checks the string actually resolves to a live
+function).
+
+The verifier's suggested remediation: extend `Get-UndefinedCommandReference` with a second AST pass
+over `HashtableAst`/key-value-pair nodes keyed `install` (or, more generally, string-literal values
+later invoked via `& $var.<key>`), validating those strings against the same
+`$definedExact`/`$definedFolded`/`Get-Command` checks already used for direct command references —
+OR add a Pester assertion that iterates `Get-DefaultAppCatalog` and asserts
+`Get-Command $app.install -ErrorAction SilentlyContinue` is non-null for every entry with an
+`install` key. Either approach is acceptable; pick whichever fits the build's existing guard
+architecture better.
+
+This repo's convention: this guard exists specifically because a prior version of this exact bug
+class (issue #154 — `Test-SystemRequirements` going missing) shipped silently once before.
+
+## Deliverable
+Either (a) an extension to `Get-UndefinedCommandReference` in
+`build/Build-WingetInstallScript.ps1` that also validates catalog-carried `install` function-name
+strings, or (b) a new Pester test in `tests/AppCatalog.Tests.ps1` that validates every catalog
+entry's `install` field resolves to a real, currently-defined function — plus a `CHANGELOG.md`
+entry documenting which approach was taken and why.
+
+## Requirements
+- R1. There must exist an automated check — as part of the build (`build/Build-WingetInstallScript.ps1`,
+  either the plain build or `-Check`) or as part of the Pester suite (`Invoke-Pester ./tests`) — that
+  fails when any `Get-DefaultAppCatalog` entry's `install` field (when present) does not name a
+  function actually defined somewhere in `WingetAppSetup/Public/*.ps1` or
+  `WingetAppSetup/Private/*.ps1`. [verify: reproduce the exact empirical repro from Context —
+  rename `Install-PowerShellLatest` to `Install-PowerShellLatestX` in its definition and the
+  `.psd1`'s `FunctionsToExport`, leave `AppCatalog.ps1`'s string as `'Install-PowerShellLatest'` —
+  and confirm the new check now fails (nonzero exit / test failure) where it previously passed]
+- R2. The check must not produce a false positive against the current, correct state of the repo
+  (every catalog entry's `install` field already resolves to a real function). [verify: run the new
+  check against the unmodified repo and confirm it passes]
+- R3. If implemented as a build guard: it must integrate into the existing guard-stack output
+  format (clear line/column-style or named-reference error message) rather than a generic crash.
+  [verify: inspect the error message produced by the R1 repro — it must clearly name the offending
+  catalog entry and the missing function]
+- R4. If implemented as a Pester test: it must follow this repo's test conventions (dot-sources
+  the module via `TestHelpers.ps1`, no reliance on real winget/system state). [verify: code review
+  of the new test file/block]
+- R5. `winget-app-install.ps1` is regenerated and `pwsh -File ./build/Build-WingetInstallScript.ps1
+  -Check` passes against the CURRENT (non-broken) repo state. [verify: run the command against the
+  actual repo, exit code 0]
+- R6. The full Pester suite passes on Pester 6.x with zero new failures (beyond the intentionally
+  new passing test) and no change to the pre-existing skip count. [verify: `Invoke-Pester ./tests`,
+  compare before/after]
+
+## Out of scope
+- Do not rename `Install-PowerShellLatest` or change the actual catalog — the repro in R1 is a
+  throwaway verification step, not a real change to ship.
+- Do not attempt to make the guard understand arbitrary indirect dispatch patterns in general —
+  scope this specifically to the catalog's `install`/similar known data-carried function-name
+  fields.
+- Do not remove or weaken any existing build guard (parse, ASCII/BOM, export, byte-compare
+  `-Check`).
+
+## Constraints
+- PowerShell 7+ syntax throughout.
+- If extending the build guard, it must remain 5.1-runtime-compatible where the build script itself
+  requires it (check `build/Build-WingetInstallScript.ps1`'s own compatibility notes, if any).
+- Whichever approach is taken, document the choice and its reasoning in a code comment, since this
+  spec explicitly allows either.
+
+## Acceptance rubric
+- C1 (from R1): PASS iff the R1 repro (empirically the same one already used to discover this bug)
+  now fails the new check where it previously passed silently.
+- C2 (from R2): PASS iff the new check passes against the current, unmodified repo.
+- C3 (from R3): PASS iff (when applicable) the failure message clearly names the broken catalog
+  entry.
+- C4 (from R4): PASS iff (when applicable) the new test follows repo test conventions.
+- C5 (from R5): PASS iff `build/Build-WingetInstallScript.ps1 -Check` exits 0 against the current
+  repo after the change.
+- C6 (from R6): PASS iff the full Pester suite shows 0 unexpected new failures and the same
+  pre-existing skip count.
+- C-final: PASS iff a domain expert reviewing this artifact would accept it without substantive
+  changes.
+
+## Open questions
+(none)

--- a/specs/consolidate-admin-check-helper.md
+++ b/specs/consolidate-admin-check-helper.md
@@ -1,0 +1,91 @@
+# Spec: Consolidate the triplicated admin-check into one shared helper
+
+## Goal
+The `IsInRole('Administrator')` check — currently copy-pasted in three files with already-diverged
+failure behavior — becomes one shared function that every call site uses, so a future change to
+how admin-detection failure is handled only has to be made once.
+
+## Context
+The identical expression
+`([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')`
+appears in three places:
+
+- `WingetAppSetup/Public/Install.ps1:66` — `$isAdmin = (...)`, no try/catch.
+- `winget-app-uninstall.ps1:15` — inline inside an `If (-NOT (...))`, no try/catch, recomputed
+  rather than stored in a variable.
+- `WingetAppSetup/Private/PowerShell7Bootstrap.ps1:182-187` — wrapped: `$isAdmin = $true` set first,
+  then `try { $isAdmin = (...) } catch { }`, with a comment explaining the try/catch exists "so the
+  unit tests stay runnable on non-Windows hosts."
+
+Verified via an independent verifier agent (CONFIRMED, full-repo review, 2026-07-16): these three
+copies have already behaviorally diverged — `PowerShell7Bootstrap.ps1`'s copy fails safe (defaults
+to admin, warns) if `GetCurrent()`/`IsInRole` ever throws; the other two would let an unhandled
+exception propagate. The verifier notes this divergence's real-world trigger (an exotic restricted
+token or non-interactive service context) is edge-case rather than commonly observed on end-user
+Windows machines — so practical risk today is low, but the inconsistency is real and the module
+already has a purpose-built place for this: `WingetAppSetup/Public/Elevation.ps1`'s own
+file-header comment says it exists specifically "so `winget-app-uninstall.ps1` doesn't hand-roll
+its own" elevation logic — yet it currently holds only `Restart-WithElevation`, not the admin check
+itself.
+
+## Deliverable
+A new shared function (e.g. `Test-IsAdmin`) added to `WingetAppSetup/Public/Elevation.ps1` (or
+`WingetAppSetup/Private/Elevation.ps1`, whichever better matches the module's public/private
+boundary for this — `winget-app-uninstall.ps1` only imports exported/Public functions via the
+`.psd1`, so if `winget-app-uninstall.ps1` needs to call it directly, it must be Public), with all
+three existing call sites updated to use it, plus new/updated Pester coverage, a regenerated
+`winget-app-install.ps1`, and a `CHANGELOG.md` entry.
+
+## Requirements
+- R1. A single function encapsulates the admin-check, including the defensive try/catch behavior
+  (fail-safe-as-admin-with-warning on unexpected exception) that `PowerShell7Bootstrap.ps1`
+  currently has and the other two call sites lack. [verify: unit test mocks
+  `[Security.Principal.WindowsIdentity]::GetCurrent()` (or the function's internal call to it) to
+  throw, and asserts the shared function returns `$true` rather than propagating the exception —
+  matching today's `PowerShell7Bootstrap.ps1` behavior, now applied everywhere]
+- R2. `WingetAppSetup/Public/Install.ps1`, `WingetAppSetup/Private/PowerShell7Bootstrap.ps1`, and
+  `winget-app-uninstall.ps1` all call the new shared function instead of the inline expression.
+  [verify: `Grep` the repo for the literal `IsInRole` expression outside the new shared function's
+  own definition — zero hits]
+- R3. Existing observable behavior at each of the three call sites is unchanged on the non-exception
+  path (an actual admin session is still detected as admin; a non-admin session is still detected
+  as non-admin). [verify: existing tests exercising elevation/admin-detection at all three call
+  sites pass unmodified or with only mechanical updates (e.g. mocking the new function name instead
+  of the raw expression)]
+- R4. `winget-app-install.ps1` is regenerated and `pwsh -File ./build/Build-WingetInstallScript.ps1
+  -Check` passes. [verify: run the command, exit code 0]
+- R5. The full Pester suite passes on Pester 6.x with zero new failures and no change to the
+  pre-existing skip count. [verify: `Invoke-Pester ./tests`, compare before/after]
+
+## Out of scope
+- Do not change what "admin" means or add new elevation logic — this is purely consolidating
+  existing, identical detection logic.
+- Do not change `Restart-WithElevation` or any other function already in `Elevation.ps1`.
+- Do not add the defensive try/catch behavior change (R1) selectively to only some call sites —
+  if consolidating, all three get the same (safer) behavior.
+
+## Constraints
+- PowerShell 7+ syntax; module source only, never hand-edit `winget-app-install.ps1`.
+- The new function must be usable both from the module (`Install.ps1`, private
+  `PowerShell7Bootstrap.ps1`) and from `winget-app-uninstall.ps1`, which imports only via the
+  `.psd1` — this determines whether the function must be Public or can stay Private with
+  `winget-app-uninstall.ps1` gaining its own thin wrapper.
+- Tests must mock the underlying `.NET` calls per repo CLAUDE.md — never rely on the actual
+  admin/non-admin state of the machine running the test.
+- Rebuild via `build/Build-WingetInstallScript.ps1` and commit the regenerated file alongside the
+  module change.
+
+## Acceptance rubric
+- C1 (from R1): PASS iff a test proves the shared function fails safe (returns `$true`, no
+  exception) when the underlying `.NET` call throws.
+- C2 (from R2): PASS iff a repo-wide search for the raw `IsInRole` expression finds it only inside
+  the new shared function's definition.
+- C3 (from R3): PASS iff existing admin-detection tests at all three call sites still pass (updated
+  mechanically if needed).
+- C4 (from R4): PASS iff `build/Build-WingetInstallScript.ps1 -Check` exits 0 after the change.
+- C5 (from R5): PASS iff the full Pester suite shows 0 new failures and the same skip count.
+- C-final: PASS iff a domain expert reviewing this artifact would accept it without substantive
+  changes.
+
+## Open questions
+(none)

--- a/specs/consolidate-winget-common-args.md
+++ b/specs/consolidate-winget-common-args.md
@@ -1,0 +1,94 @@
+# Spec: Consolidate the duplicated winget agreement/interactivity flag-triple into one helper
+
+## Goal
+The `--accept-source-agreements --accept-package-agreements --disable-interactivity` flag
+combination (and its subcommand-specific variants) is built by one shared helper instead of being
+hand-duplicated across call sites, so the exact class of bug that already shipped once (a missing
+flag caught only after the fact, issue #230) becomes structurally impossible instead of relying on
+manual re-auditing.
+
+## Context
+Three call sites independently build this flag combination as inline literal arrays:
+
+- `WingetAppSetup/Public/WingetCore.ps1:347-353` — `Install-WingetPackage`'s `$installArgs`:
+  `'install', '-e', '--accept-source-agreements', '--accept-package-agreements',
+  '--disable-interactivity', '--source', 'winget', '--id', $PackageId`. Carries a comment (lines
+  342-346) explicitly citing issue #230: this exact array was the one missing
+  `--disable-interactivity` while every other winget call in the module already had it.
+- `WingetAppSetup/Public/WingetCore.ps1:606-610` — `Install-MsixProvisionedPackage`'s
+  `$downloadArgs`: same three flags plus `download`-specific arguments.
+- `WingetAppSetup/Private/PowerShell7Bootstrap.ps1:201` — `$wingetArguments` for the PowerShell 7
+  winget install: same three flags plus its own subcommand-specific arguments.
+
+Verified via an independent verifier agent (CONFIRMED, full-repo review, 2026-07-16), confirmed by
+the commit that fixed issue #230 (`ba6bd91`) touching exactly these call sites (plus a fourth,
+`Invoke-WingetInstall`'s source-update call, which needed only `--disable-interactivity` since
+`winget source update` cannot take `--accept-source-agreements` — see
+`WingetAppSetup/Private/WingetBootstrap.ps1:10`). The verifier's own honest assessment: this is
+real but "marginal, not urgent" — other winget call sites (`source list`, `search`, `source reset`,
+`source update`) use different, subcommand-specific flag subsets, so a single one-size-fits-all
+helper needs conditional logic per subcommand rather than being a clean drop-in replacement for
+all winget calls; the team's actual chosen mitigation so far has been per-call `Should -Contain`
+Pester assertions rather than structural consolidation.
+
+## Deliverable
+A shared helper function (e.g. `Get-WingetAgreementArgs` or similar) in
+`WingetAppSetup/Private/` that returns the base agreement/interactivity flags, used by
+`Install-WingetPackage`, `Install-MsixProvisionedPackage`, and the PowerShell 7 bootstrap's winget
+install call — each still appending its own subcommand-specific arguments around the shared base —
+plus new/updated Pester coverage, a regenerated `winget-app-install.ps1`, and a `CHANGELOG.md`
+entry.
+
+## Requirements
+- R1. A single function/helper returns the base flag set (`--accept-source-agreements
+  --accept-package-agreements --disable-interactivity`, or the correct subset for a given
+  subcommand if the helper is parameterized by subcommand). [verify: unit test calls the helper
+  directly and asserts it returns exactly the expected flags]
+- R2. `Install-WingetPackage`, `Install-MsixProvisionedPackage`, and the PowerShell 7 bootstrap's
+  winget-install call site each use the shared helper rather than a hand-written literal array for
+  the shared flag portion. [verify: unit test mocks/spies the helper and asserts each of the three
+  call sites' constructed argument list contains the helper's output, or — equivalently — `Grep` the
+  repo for the raw three-flag literal combination outside the helper's own definition returns zero
+  hits]
+- R3. Each call site's own subcommand-specific arguments (e.g. `--source winget --id $PackageId` for
+  install, `--installer-type msix --download-directory $downloadDir` for download) are unaffected —
+  only the shared agreement/interactivity portion is deduplicated. [verify: existing
+  `tests/WingetCore.Tests.ps1` / `tests/PowerShell7Bootstrap.Tests.ps1` argument-shape assertions
+  (the `Should -Contain` checks the verifier found) continue to pass, updated only mechanically if
+  the exact array construction changed]
+- R4. `winget-app-install.ps1` is regenerated and `pwsh -File ./build/Build-WingetInstallScript.ps1
+  -Check` passes. [verify: run the command, exit code 0]
+- R5. The full Pester suite passes on Pester 6.x with zero new failures and no change to the
+  pre-existing skip count. [verify: `Invoke-Pester ./tests`, compare before/after]
+
+## Out of scope
+- Do not touch `winget source update`, `winget source list`, `winget search`, or `winget source
+  reset` call sites — their flag sets are already correct and are a different subset (some, like
+  `source update`, must NOT take `--accept-source-agreements` per issues #174/#175 — do not add it).
+- Do not change any winget subcommand's actual behavior or add new flags beyond what each call site
+  already passes today.
+- Do not attempt to build a fully generic "any winget command" wrapper — scope this to the shared
+  agreement/interactivity portion only, per the verifier's own recommendation against
+  over-engineering a one-size-fits-all abstraction.
+
+## Constraints
+- PowerShell 7+ syntax; module source only, never hand-edit `winget-app-install.ps1`.
+- The helper must live in `WingetAppSetup/Private/` unless a call site outside the module needs it
+  directly (none currently do — `winget-app-uninstall.ps1`'s raw `winget uninstall` call is
+  explicitly out of scope here, tracked separately).
+- Tests must mock all external winget calls per repo CLAUDE.md.
+- Rebuild via `build/Build-WingetInstallScript.ps1` and commit the regenerated file alongside the
+  module change.
+
+## Acceptance rubric
+- C1 (from R1): PASS iff a direct unit test of the new helper returns the expected flag set.
+- C2 (from R2): PASS iff all three call sites use the helper and no raw duplicate of the three-flag
+  literal remains outside it.
+- C3 (from R3): PASS iff each call site's subcommand-specific arguments are provably unaffected.
+- C4 (from R4): PASS iff `build/Build-WingetInstallScript.ps1 -Check` exits 0 after the change.
+- C5 (from R5): PASS iff the full Pester suite shows 0 new failures and the same skip count.
+- C-final: PASS iff a domain expert reviewing this artifact would accept it without substantive
+  changes.
+
+## Open questions
+(none)

--- a/specs/install-powershell-latest-verify-timeout.md
+++ b/specs/install-powershell-latest-verify-timeout.md
@@ -1,0 +1,78 @@
+# Spec: `Install-PowerShellLatest`'s verification calls need the timeout every other app already gets
+
+## Goal
+Verifying whether PowerShell itself installed successfully must be bounded by the same timeout
+every other catalog app's verification already uses, so a hung `winget list` during this one app's
+check fails into the retry pass instead of blocking the entire run forever.
+
+## Context
+`WingetAppSetup/Public/WingetCore.ps1`'s `Test-WingetPackageInstalled` (lines 425-479) takes an
+optional `-TimeoutSeconds` (default `0`, line 431). When greater than 0 (lines 434-470), it runs
+`winget list` via a timeout-guarded `Start-Process`/`WaitForExit`/`Kill()` pattern. When omitted
+(the default), it falls through to lines 472-479: a bare, untimed `winget list ... 2>&1` call with
+no way to bound or kill it.
+
+`Install-PowerShellLatest` (same file, lines 669-694) calls `Test-WingetPackageInstalled` twice —
+line 682 (MSI path) and line 689 (native-MSIX path) — and **neither call passes
+`-TimeoutSeconds`**, so both hit the untimed fallback.
+
+By contrast, `WingetAppSetup/Private/InstallVerification.ps1`'s `Install-AppWithVerification` sets
+`$checkTimeoutSeconds = 15` (line 84) and passes it explicitly on both its pre-check (line 86) and
+post-verify (line 118) calls — the pipeline every other catalog app's verification goes through.
+
+Verified via direct read and an independent verifier agent (CONFIRMED, full-repo review,
+2026-07-16): this is a genuine, real asymmetry — every other verification call in the pipeline is
+timeout-guarded; PowerShell's own self-verification is not. A hang here blocks the whole run
+instead of failing into the retry pass like any other app would.
+
+This repo's convention: the module is the source of truth; tests use Pester 6.x and mock all
+external calls.
+
+## Deliverable
+A code change to `WingetAppSetup/Public/WingetCore.ps1`'s `Install-PowerShellLatest` function
+(lines 682 and 689), passing an explicit `-TimeoutSeconds` to both `Test-WingetPackageInstalled`
+calls, plus new/updated Pester coverage in `tests/WingetCore.Tests.ps1`, a regenerated
+`winget-app-install.ps1`, and a `CHANGELOG.md` entry.
+
+## Requirements
+- R1. Both calls to `Test-WingetPackageInstalled` inside `Install-PowerShellLatest` (the MSI-path
+  call and the native-MSIX-path call) must pass an explicit `-TimeoutSeconds` value greater than 0.
+  [verify: unit test mocks `Test-WingetPackageInstalled` and asserts it is invoked with
+  `-TimeoutSeconds` bound to a value `-gt 0` on both call paths]
+- R2. The timeout value used must match the value already used elsewhere in the pipeline (15
+  seconds, per `Install-AppWithVerification`'s `$checkTimeoutSeconds`), or the reviewer must be able
+  to see a documented reason for a different value. [verify: code review of the literal/constant
+  used; if it differs from 15, a comment explains why]
+- R3. Existing behavior when the check completes normally (no hang) must be unchanged — the
+  function still returns the same `@{ ExitCode; Installed; Method }` shape it does today. [verify:
+  existing tests for `Install-PowerShellLatest`'s return shape continue to pass unmodified]
+- R4. `winget-app-install.ps1` is regenerated and `pwsh -File ./build/Build-WingetInstallScript.ps1
+  -Check` passes. [verify: run the command, exit code 0]
+- R5. The full Pester suite passes on Pester 6.x with zero new failures and no change to the
+  pre-existing skip count. [verify: `Invoke-Pester ./tests`, compare before/after]
+
+## Out of scope
+- Do not change `Test-WingetPackageInstalled` itself — its existing timeout mechanism already works
+  correctly; this fix is purely about `Install-PowerShellLatest` passing the parameter.
+- Do not change `Install-AppWithVerification` or any other caller of `Test-WingetPackageInstalled`.
+- Do not add retry logic beyond what already exists in the surrounding pipeline.
+
+## Constraints
+- PowerShell 7+ syntax; module source only, never hand-edit `winget-app-install.ps1`.
+- Tests must mock `Test-WingetPackageInstalled` (or the underlying `Start-Process`) per repo
+  CLAUDE.md — never rely on real winget/system state.
+- Rebuild via `build/Build-WingetInstallScript.ps1` and commit the regenerated file alongside the
+  module change.
+
+## Acceptance rubric
+- C1 (from R1): PASS iff both calls in `Install-PowerShellLatest` pass a `-TimeoutSeconds` value
+  greater than 0, provable by a test.
+- C2 (from R2): PASS iff the value used is 15 or a documented deviation from 15.
+- C3 (from R3): PASS iff existing return-shape tests for `Install-PowerShellLatest` pass unmodified.
+- C4 (from R4): PASS iff `build/Build-WingetInstallScript.ps1 -Check` exits 0 after the change.
+- C5 (from R5): PASS iff the full Pester suite shows 0 new failures and the same skip count.
+- C-final: PASS iff a domain expert reviewing this artifact would accept it without substantive
+  changes.
+
+## Open questions
+(none)

--- a/specs/package-id-regex-validation.md
+++ b/specs/package-id-regex-validation.md
@@ -1,0 +1,89 @@
+# Spec: Implement the package-ID regex validation CLAUDE.md already documents
+
+## Goal
+Package IDs are validated against the shape this repo's own CLAUDE.md mandates before being
+trusted in winget output or passed to winget commands — closing the gap between a documented rule
+and actual enforcement.
+
+## Context
+`CLAUDE.md` (repo root, "Winget Notes" section, line 55) states verbatim:
+
+> Validate package IDs with regex before trusting winget output: `^[\w][\w.\-]+\.[\w][\w.\-]+`
+
+Verified via direct read and an independent verifier agent (CONFIRMED, full-repo review,
+2026-07-16): this pattern exists nowhere in production code. `Test-WingetPackageInstalled`
+(`WingetAppSetup/Public/WingetCore.ps1`, lines 458 and 474) decides "is this installed" via a plain
+`.Contains($PackageId)` against raw `winget list` text output — no regex, no anchoring.
+`Install-WingetPackage` (same file, line 352) passes `$PackageId` into the `--id` argument with no
+prior validation. `WingetAppSetup/Public/AppValidation.ps1`'s `Test-AppDefinitions` (lines 29-32)
+only checks that `name` is a non-empty, non-whitespace string — no shape check. The only place the
+regex appears is `tests/AppCatalog.Tests.ps1:64`, which uses it solely to assert the static
+catalog's hardcoded names have the right shape at test time — it validates nothing at runtime.
+
+Risk is partially mitigated today because `Test-WingetPackageInstalled` calls `winget list --exact
+--id $PackageId`, so winget itself narrows the result set before the `.Contains` check runs — but
+the CLAUDE.md rule is still unenforced as written, and an unanchored substring check against
+`winget list` output remains theoretically exploitable to a false "installed" verdict.
+
+This repo's convention: the module is the source of truth; `Get-DefaultAppCatalog`
+(`WingetAppSetup/Public/AppCatalog.ps1`) is the curated, trusted source of package IDs — this
+validation is a defense-in-depth check, not a defense against a hostile catalog.
+
+## Deliverable
+A code change adding package-ID shape validation at the two places IDs are trusted:
+`Test-AppDefinitions` (`WingetAppSetup/Public/AppValidation.ps1`) for catalog entries at load time,
+and `Test-WingetPackageInstalled`'s installed-check (`WingetAppSetup/Public/WingetCore.ps1`) for
+runtime output matching — plus new/updated Pester coverage, a regenerated
+`winget-app-install.ps1`, and a `CHANGELOG.md` entry.
+
+## Requirements
+- R1. `Test-AppDefinitions` must reject (add to its `Errors`/`Warnings` collection, per its
+  existing return-shape contract) any catalog entry whose `name` does not match
+  `^[\w][\w.\-]+\.[\w][\w.\-]+`. [verify: unit test passes a catalog entry with a malformed id
+  (e.g. missing the dot-separated publisher.product shape) and asserts `Test-AppDefinitions`
+  reports it as invalid, while every existing real catalog entry from `Get-DefaultAppCatalog`
+  still passes]
+- R2. `Test-WingetPackageInstalled`'s installed-determination must not treat a `winget list` output
+  line as a match unless the matched substring corresponds to a package ID of the same validated
+  shape (i.e. tighten the match so an unrelated line containing `$PackageId` as a pure substring of
+  a different token cannot false-positive). [verify: unit test constructs mock `winget list` output
+  containing a different package ID that contains the target `$PackageId` as a substring (e.g.
+  target `Foo.Bar` inside listed id `Foo.BarBaz`), and asserts `Test-WingetPackageInstalled` returns
+  `$false`/not-installed for that case, while a real matching line still returns `$true`]
+- R3. Existing behavior for well-formed package IDs (the entire current catalog) must be completely
+  unchanged. [verify: full existing `tests/WingetCore.Tests.ps1` and `tests/AppCatalog.Tests.ps1`
+  suites pass unmodified]
+- R4. `winget-app-install.ps1` is regenerated and `pwsh -File ./build/Build-WingetInstallScript.ps1
+  -Check` passes. [verify: run the command, exit code 0]
+- R5. The full Pester suite passes on Pester 6.x with zero new failures and no change to the
+  pre-existing skip count. [verify: `Invoke-Pester ./tests`, compare before/after]
+
+## Out of scope
+- Do not change the curated catalog's actual entries in `AppCatalog.ps1` — all current entries are
+  already well-formed and must continue to validate successfully.
+- Do not add validation to `winget-app-uninstall.ps1`'s separate raw `winget uninstall` call — that
+  is out of scope for this fix (track separately if desired).
+- Do not change how `--exact --id` narrowing works in the underlying winget invocation.
+
+## Constraints
+- PowerShell 7+ syntax; module source only, never hand-edit `winget-app-install.ps1`.
+- Use the exact regex CLAUDE.md specifies: `^[\w][\w.\-]+\.[\w][\w.\-]+` — do not invent a
+  different pattern.
+- Tests must mock all external winget calls per repo CLAUDE.md.
+- Rebuild via `build/Build-WingetInstallScript.ps1` and commit the regenerated file alongside the
+  module change.
+
+## Acceptance rubric
+- C1 (from R1): PASS iff a test proves `Test-AppDefinitions` rejects a malformed id and accepts
+  every real catalog entry.
+- C2 (from R2): PASS iff a test proves a substring-collision scenario no longer false-positives as
+  installed, while a real match still succeeds.
+- C3 (from R3): PASS iff `tests/WingetCore.Tests.ps1` and `tests/AppCatalog.Tests.ps1` pass
+  unmodified.
+- C4 (from R4): PASS iff `build/Build-WingetInstallScript.ps1 -Check` exits 0 after the change.
+- C5 (from R5): PASS iff the full Pester suite shows 0 new failures and the same skip count.
+- C-final: PASS iff a domain expert reviewing this artifact would accept it without substantive
+  changes.
+
+## Open questions
+(none)

--- a/specs/remove-dead-environment-path-code.md
+++ b/specs/remove-dead-environment-path-code.md
@@ -1,0 +1,95 @@
+# Spec: Remove the orphaned PATH-mutation helpers left behind by issue #179
+
+## Goal
+`WingetAppSetup/Private/Environment.ps1`'s PATH-mutation functions — dead since the feature that
+used them was removed — are deleted, leaving the module with no unused private helpers pretending
+to be live code.
+
+## Context
+`WingetAppSetup/Public/Install.ps1` (lines 171-174) carries this comment:
+
+> Note: earlier versions added the script's own directory (often Downloads/) to the persistent User
+> PATH here for the homegrown updater. The updater is gone (#168) and a user-writable directory on
+> the PATH of an elevating account is a hijack surface, so no PATH changes are made anymore (issue
+> #179).
+
+`tests/Install.Tests.ps1` (line 66) has a regression assertion,
+`$installBody | Should -Not -Match 'Add-ToEnvironmentPath'`, proving the removal from the install
+path was deliberate and guarded.
+
+But `WingetAppSetup/Private/Environment.ps1` itself was never cleaned up. It still defines:
+`Add-ToEnvironmentPath` (line 116), `Test-PathInEnvironment` (line 158),
+`Test-PathListContainsEntry` (line 39), `Get-PersistedEnvironmentPath` (line 67), and
+`Set-PersistedEnvironmentPath` (line 89).
+
+Verified via an independent verifier agent (CONFIRMED, full-repo review, 2026-07-16): a repo-wide
+grep (excluding `.claude/worktrees/` and `tests/`) for all five function names found zero real
+callers anywhere in `WingetAppSetup/Public/`, `build/`, `e2e/`, `winget-app-install.ps1`, or
+`winget-app-uninstall.ps1` — only their own internal cross-calls (`Add-ToEnvironmentPath` calling
+`Test-PathInEnvironment`, `Test-PathInEnvironment` calling `Get-PersistedEnvironmentPath` and
+`Test-PathListContainsEntry`) and their dedicated test file, `tests/Environment.Tests.ps1`. The file
+is in `Private/`, so none of these functions are exported via `WingetAppSetup.psd1`'s
+`FunctionsToExport` either — there is no external consumer to preserve compatibility for.
+
+## Deliverable
+Deletion of the five orphaned functions from `WingetAppSetup/Private/Environment.ps1` (or deletion
+of the whole file if nothing else in it is still used — `Get-WindowsBuildNumber` and
+`Get-ComputerManufacturer`, lines 1-24, ARE still live and must be preserved, likely by moving them
+to a different/renamed file), deletion of their now-pointless dedicated tests, a regenerated
+`winget-app-install.ps1`, and a `CHANGELOG.md` entry.
+
+## Requirements
+- R1. `Add-ToEnvironmentPath`, `Test-PathInEnvironment`, `Test-PathListContainsEntry`,
+  `Get-PersistedEnvironmentPath`, and `Set-PersistedEnvironmentPath` no longer exist anywhere in
+  `WingetAppSetup/`. [verify: `Get-Command -Name Add-ToEnvironmentPath -ErrorAction
+  SilentlyContinue` (and the other four) returns `$null` after dot-sourcing the module in a test
+  session]
+- R2. `Get-WindowsBuildNumber` and `Get-ComputerManufacturer` — the two functions in the same file
+  that ARE still used (by `Install-PowerShellLatest`'s build-number gate and the catalog's Dell
+  Command Update applicability condition, respectively) — continue to work exactly as before,
+  regardless of which file they end up living in. [verify: existing tests exercising
+  `Get-WindowsBuildNumber` and `Get-ComputerManufacturer` (or their consumers) pass unmodified]
+- R3. `tests/Environment.Tests.ps1`'s tests for the five removed functions are deleted; any tests
+  in that file for `Get-WindowsBuildNumber`/`Get-ComputerManufacturer` are preserved (moved if the
+  file itself is renamed/reorganized). [verify: `Invoke-Pester ./tests` shows no test names
+  referencing the five removed functions, and the two retained functions still have test coverage]
+- R4. `winget-app-install.ps1` is regenerated (the five functions and their tests disappear from the
+  generated artifact and its build-time undefined-reference checks) and `pwsh -File
+  ./build/Build-WingetInstallScript.ps1 -Check` passes. [verify: run the command, exit code 0; grep
+  the regenerated file for the five removed names — zero hits outside comments/CHANGELOG]
+- R5. The full Pester suite passes on Pester 6.x with zero new failures, and the total test count
+  decreases by exactly the number of deleted tests (no accidental deletion of unrelated tests).
+  [verify: compare `Invoke-Pester ./tests` total test count before and after]
+
+## Out of scope
+- Do not remove or alter `Get-WindowsBuildNumber` or `Get-ComputerManufacturer` — only the five
+  PATH-mutation functions are dead.
+- Do not re-investigate whether the PATH-mutation feature should be restored — issue #179's decision
+  to remove it stands; this spec only finishes that cleanup.
+- Do not touch `WingetAppSetup/Public/Install.ps1`'s explanatory comment about why no PATH changes
+  are made — it remains accurate and useful context.
+
+## Constraints
+- PowerShell 7+ syntax; module source only, never hand-edit `winget-app-install.ps1`.
+- If splitting `Get-WindowsBuildNumber`/`Get-ComputerManufacturer` into a new or differently-named
+  file, update `WingetAppSetup/WingetAppSetup.psm1`'s loader (if it lists files explicitly) and any
+  path references in tests accordingly.
+- Rebuild via `build/Build-WingetInstallScript.ps1` and commit the regenerated file alongside the
+  module change.
+
+## Acceptance rubric
+- C1 (from R1): PASS iff `Get-Command` for all five removed function names returns `$null` after
+  the change.
+- C2 (from R2): PASS iff `Get-WindowsBuildNumber`/`Get-ComputerManufacturer` and their consumer
+  tests still pass unmodified.
+- C3 (from R3): PASS iff no test names reference the five removed functions, and the two retained
+  functions keep coverage.
+- C4 (from R4): PASS iff the regenerated installer contains zero non-comment references to the five
+  removed functions and `-Check` exits 0.
+- C5 (from R5): PASS iff the Pester suite shows 0 new failures and a test-count decrease matching
+  exactly what was deleted.
+- C-final: PASS iff a domain expert reviewing this artifact would accept it without substantive
+  changes.
+
+## Open questions
+(none)

--- a/specs/retry-pass-failure-message-mislabel.md
+++ b/specs/retry-pass-failure-message-mislabel.md
@@ -1,0 +1,102 @@
+# Spec: Retry-pass failure messages must name the actual failed phase, not always "verification"
+
+## Goal
+When a retried app fails because its pre-check (`winget list`) timed out, the printed message must
+say so — not claim "verification timed out," which misattributes which pipeline phase actually
+failed and misleads whoever is reading the output to diagnose it.
+
+## Context
+`WingetAppSetup/Public/Install.ps1`'s `Invoke-WingetInstall` has two loops that both convert a
+failed `Install-AppWithVerification` outcome into a human-readable message via
+`Format-InstallFailureReason`.
+
+**First pass** (lines 245-262):
+```powershell
+switch ($outcome.FailureReason) {
+    'PreCheckTimeout' {
+        Write-WarningMessage "Winget list timed out for $($app.name). Marking as failed; it will be retried."
+    }
+    'VerifyTimeout' {
+        Write-WarningMessage "Verification timed out for: $($app.name). Assuming installation failed."
+    }
+    default {
+        Write-ErrorMessage "Failed to install: $($app.name) ($failureReason)."
+    }
+}
+```
+
+**Retry pass** (lines 306-313):
+```powershell
+if ($outcome.FailureReason -in 'PreCheckTimeout', 'VerifyTimeout') {
+    Write-WarningMessage "Verification timed out for retry: $appName. Assuming installation failed."
+}
+else {
+    Write-ErrorMessage "Retry failed: $appName ($failureReason)."
+}
+```
+
+Verified via an independent verifier agent (CONFIRMED, full-repo review, 2026-07-16): the first
+pass gives `PreCheckTimeout` its own distinct wording; the retry pass collapses `PreCheckTimeout`
+and `VerifyTimeout` into one branch, both printing "Verification timed out for retry" — mislabeling
+a pre-check timeout as a verification timeout. A user diagnosing a retry failure reads "Verification
+timed out" and reasonably concludes the install itself likely succeeded but post-install
+verification couldn't confirm it, when the real story (for `PreCheckTimeout`) is that the pre-check
+(`winget list`, checking whether the app is already installed) never even completed. This is a
+materially misleading attribution, not a cosmetic wording difference.
+
+## Deliverable
+A code change to the retry-pass loop in `Invoke-WingetInstall` (`WingetAppSetup/Public/Install.ps1`,
+currently lines 306-315) so it distinguishes `PreCheckTimeout` from `VerifyTimeout` the same way the
+first pass already does, plus new/updated Pester coverage, a regenerated
+`winget-app-install.ps1`, and a `CHANGELOG.md` entry.
+
+## Requirements
+- R1. When a retry's `$outcome.FailureReason` is `'PreCheckTimeout'`, the retry pass must print a
+  message that names the pre-check/`winget list` phase specifically (not "verification"), analogous
+  to the first pass's wording, adapted for "retry" context (e.g. mentioning "retry" the way the
+  current retry messages already do). [verify: unit test drives the retry loop with a mocked
+  outcome of `FailureReason = 'PreCheckTimeout'` and asserts the printed message text does not say
+  "Verification timed out" and does reference the pre-check/list phase]
+- R2. When a retry's `$outcome.FailureReason` is `'VerifyTimeout'`, the retry pass must continue to
+  print a verification-timeout-specific message — this case is not being changed, only decoupled
+  from `PreCheckTimeout`. [verify: unit test drives the retry loop with `FailureReason =
+  'VerifyTimeout'` and asserts the existing "Verification timed out for retry" wording (or
+  equivalent) is preserved]
+- R3. All other `FailureReason` values on retry must continue to fall through to the existing
+  generic "Retry failed: ... (reason)" message. [verify: existing tests for the generic retry-failure
+  path continue to pass unmodified]
+- R4. The `$failedApps` tracking (`@{ Name; Reason }`) must be unaffected — this fix is purely about
+  the printed warning/error text, not the data recorded for the summary table. [verify: existing
+  summary-table tests pass unmodified]
+- R5. `winget-app-install.ps1` is regenerated and `pwsh -File ./build/Build-WingetInstallScript.ps1
+  -Check` passes. [verify: run the command, exit code 0]
+- R6. The full Pester suite passes on Pester 6.x with zero new failures and no change to the
+  pre-existing skip count. [verify: `Invoke-Pester ./tests`, compare before/after]
+
+## Out of scope
+- Do not change the first-pass loop's messages — they are already correct and are the reference
+  behavior this fix aligns the retry pass to.
+- Do not change `Format-InstallFailureReason` or the `FailureReason` values themselves.
+- Do not change retry counts, backoff, or any other retry-pass logic besides message selection.
+
+## Constraints
+- PowerShell 7+ syntax; module source only, never hand-edit `winget-app-install.ps1`.
+- Keep the retry-specific phrasing convention already in use (messages mention "retry" explicitly,
+  e.g. "for retry", "Retry failed") rather than copying the first-pass wording verbatim.
+- Tests must mock `Install-AppWithVerification`'s outcome per repo CLAUDE.md conventions.
+- Rebuild via `build/Build-WingetInstallScript.ps1` and commit the regenerated file alongside the
+  module change.
+
+## Acceptance rubric
+- C1 (from R1): PASS iff a test proves a `PreCheckTimeout` retry no longer says "Verification timed
+  out" and instead names the pre-check phase.
+- C2 (from R2): PASS iff a test proves `VerifyTimeout` retry messaging is unchanged.
+- C3 (from R3): PASS iff the generic retry-failure message path is unaffected.
+- C4 (from R4): PASS iff the `$failedApps` data shape and summary-table tests are unaffected.
+- C5 (from R5): PASS iff `build/Build-WingetInstallScript.ps1 -Check` exits 0 after the change.
+- C6 (from R6): PASS iff the full Pester suite shows 0 new failures and the same skip count.
+- C-final: PASS iff a domain expert reviewing this artifact would accept it without substantive
+  changes.
+
+## Open questions
+(none)

--- a/specs/whatif-ignored-iex-elevation.md
+++ b/specs/whatif-ignored-iex-elevation.md
@@ -1,0 +1,97 @@
+# Spec: `-WhatIf` must preview instead of demanding elevation on the IEX/remote path
+
+## Goal
+A non-admin user running the documented one-liner (`irm <url> | iex`) with `-WhatIf` gets a dry-run
+preview, the same way a non-admin local-file run already does — instead of an unconditional
+"requires administrator privileges" failure that never looks at `-WhatIf` at all.
+
+## Context
+`Invoke-WingetInstall` (`WingetAppSetup/Public/Install.ps1`) has two branches for a non-admin
+session, gated on `Test-IsRunningLocally` (`WingetAppSetup/Private/Elevation.ps1:10`, which returns
+`$false` whenever `$PSScriptRoot` is empty or invalid — the case for every `irm | iex` run, since
+there is no on-disk script file).
+
+- **Local-file branch** (`Install.ps1:79-114`): explicitly checks `$WhatIf` first (line 84). When
+  true, it prints `'[DRY-RUN] Would relaunch with administrator privileges. Continuing the preview
+  in the current (non-elevated) session; no system changes will be made.'` and falls through
+  without elevating or exiting.
+- **IEX/remote branch** (`Install.ps1:116-124`, the `else` of the `if (Test-IsRunningLocally)` at
+  line 79): never references `$WhatIf` at all. It unconditionally prints "This script requires
+  administrator privileges" / "Auto-elevation is unavailable when running through IEX/remote
+  execution", sleeps 5 seconds, and calls `Exit 1`.
+
+Verified via direct read and an independent verifier agent (both CONFIRMED, full-repo review,
+2026-07-16): no earlier guard in `Invoke-WingetInstall` or in `build/fragments/tail.ps1` (which
+just forwards `-WhatIf:$WhatIf` into the function) intercepts this combination before it reaches
+the `else` branch. No existing test drives non-admin + `Test-IsRunningLocally` false + `-WhatIf`
+true: `tests/EntryPoint.Tests.ps1`'s only real (non-mocked) IEX/non-admin test omits `-WhatIf`, and
+every `Invoke-WingetInstall` `-WhatIf` test in `tests/Install.Tests.ps1` mocks `Test-IsRunningLocally`
+to always return `$true`.
+
+This repo's convention: the module (`WingetAppSetup/Public/*.ps1`) is the single source of truth;
+`winget-app-install.ps1` is generated from it via `build/Build-WingetInstallScript.ps1` and must
+never be hand-edited. Tests use Pester 6.x (`Import-Module Pester -MinimumVersion 6.0.0
+-MaximumVersion 6.999.999`), mock every external call, and use unconditional `Mock` in `BeforeEach`
+rather than conditional stubs.
+
+## Deliverable
+A code change to `WingetAppSetup/Public/Install.ps1`'s `Invoke-WingetInstall` function (the `else`
+branch at what is currently lines 116-124), plus new/updated Pester coverage in
+`tests/Install.Tests.ps1`, plus a regenerated `winget-app-install.ps1` (via
+`build/Build-WingetInstallScript.ps1`) and a `CHANGELOG.md` entry under `[Unreleased]`.
+
+## Requirements
+- R1. When `$isAdmin` is false, `Test-IsRunningLocally` is false, and `$WhatIf` is `$true`, the
+  function must NOT call `Exit` and must NOT print the "requires administrator privileges" /
+  "Auto-elevation is unavailable" messages. [verify: unit test mocks `Test-IsRunningLocally` to
+  return `$false`, calls `Invoke-WingetInstall -WhatIf`, and asserts the function returns normally
+  (no `Exit` invoked) and `Write-ErrorMessage`/`Write-Info` are never called with those exact
+  strings]
+- R2. In that same scenario, the function must print a dry-run message analogous to the
+  local-file branch's, explicitly stating that elevation would be required for a real run and that
+  no system changes are being made. [verify: unit test asserts `Write-Info` (or equivalent) is
+  invoked with a message matching `-WhatIf` / `[DRY-RUN]` conventions already used elsewhere in
+  this function, e.g. `-match '\[DRY-RUN\]'`]
+- R3. The pre-existing behavior for `$WhatIf` false in this same non-admin/IEX combination must be
+  unchanged: still prints the two error/info messages, still sleeps, still exits 1. [verify:
+  existing test `tests/EntryPoint.Tests.ps1`'s "Should exit with code 1 and show remote elevation
+  guidance" test (or its Install.Tests.ps1 equivalent) continues to pass unmodified]
+- R4. The pre-existing local-file `-WhatIf` behavior (lines 79-114) must be unchanged. [verify:
+  existing Pester tests covering that branch continue to pass unmodified]
+- R5. `winget-app-install.ps1` is regenerated and `pwsh -File ./build/Build-WingetInstallScript.ps1
+  -Check` passes. [verify: run the command, exit code 0, output "up to date"]
+- R6. The full Pester suite passes on Pester 6.x with zero new failures and no reduction in the
+  pre-existing skip count (currently 3). [verify: `Invoke-Pester ./tests`, compare pass/fail/skip
+  counts before and after]
+
+## Out of scope
+- Do not change the local-file (`Test-IsRunningLocally` true) branch's behavior or messages.
+- Do not change what happens when `$WhatIf` is false on the IEX/remote path (R3 pins this).
+- Do not add a mechanism to actually preview installs differently on the IEX path than the
+  local-file path already does — reuse the exact same dry-run messaging convention.
+- Do not touch elevation, UAC, or any other prompt-related behavior — this is scoped purely to the
+  `$WhatIf` gate on this one branch.
+
+## Constraints
+- PowerShell 7+ syntax; edit the module source only, never hand-edit `winget-app-install.ps1`.
+- Follow this repo's existing message-formatting conventions (`Write-Info`, `[DRY-RUN]` prefix)
+  rather than inventing new ones.
+- Tests must mock all external calls (no real `Exit`, no real elevation) per repo CLAUDE.md.
+- Rebuild via `build/Build-WingetInstallScript.ps1` and commit the regenerated file alongside the
+  module change (repo convention: they always change together).
+
+## Acceptance rubric
+- C1 (from R1): PASS iff a test proves `Invoke-WingetInstall -WhatIf` with `Test-IsRunningLocally`
+  mocked false does not exit and does not print the admin-required messages.
+- C2 (from R2): PASS iff that same scenario prints a `[DRY-RUN]`-style preview message.
+- C3 (from R3): PASS iff the non-`WhatIf` IEX/remote exit-1 behavior is provably unchanged (test
+  still passes without modification to its assertions).
+- C4 (from R4): PASS iff the local-file `-WhatIf` branch's tests still pass unmodified.
+- C5 (from R5): PASS iff `build/Build-WingetInstallScript.ps1 -Check` exits 0 after the change.
+- C6 (from R6): PASS iff the full Pester suite shows 0 new failures and the same skip count as
+  before the change.
+- C-final: PASS iff a domain expert reviewing this artifact would accept it without substantive
+  changes.
+
+## Open questions
+(none)

--- a/specs/winget-source-health-exit-code-classification.md
+++ b/specs/winget-source-health-exit-code-classification.md
@@ -1,0 +1,97 @@
+# Spec: Reduce locale-fragile prose matching in winget source-corruption detection
+
+## Goal
+`Test-WingetSourceHealth`'s corruption detection relies less on matching English prose from winget
+output and more on the numeric exit code / HRESULT signal this module already uses everywhere else,
+so a winget CLI locale or wording change is less likely to silently break corruption detection.
+
+## Context
+`WingetAppSetup/Private/WingetBootstrap.ps1`'s `Test-WingetSourceHealth` (function starts line 91)
+classifies a `winget search` result as functional or corrupted at line 117:
+
+```powershell
+if ($searchOutput -match '0x8a150|failed when opening|data required' -or $searchExitCode -ne 0) {
+```
+
+Verified via an independent verifier agent (PLAUSIBLE — real fragility, but the initial framing was
+corrected, full-repo review, 2026-07-16): this is NOT prose-matching *instead of* exit-code
+checking — the same line already ORs in `$searchExitCode -ne 0`, so any nonzero exit already fails
+the check regardless of text. The prose match supplements the exit-code check specifically because
+(per the codebase's own hard-won history with flaky winget exit codes, documented across issues
+#150/#172/#174/#175/#177) winget can reportedly emit a corruption signature like `0x8a15000f`
+("Failed when opening source(s)... Data required by the source is missing") while still returning
+exit code 0 in some observed cases.
+
+The verifier found a viable numeric alternative for at least part of the pattern:
+`0x8a15000f` as a signed Int32 HRESULT is `-1978335217` — directly adjacent to the other HRESULT
+constants this module already checks numerically elsewhere (`-1978335216`, `-1978335162` in
+`WingetCore.ps1`). The two literal English phrases (`'failed when opening'`, `'data required'`)
+are the genuinely locale-fragile part, and — unlike a similar function in
+`winget-app-uninstall.ps1:48` which has an explicit "winget output is locale-dependent (issue
+#180)" comment — this function has no such acknowledgment. `tests/WingetBootstrap.Tests.ps1:58-76`
+only exercises the corrupted-text case paired with a nonzero exit code, never isolating the prose
+match's independent effect (i.e. corrupted text + exit code 0, which is the scenario the prose
+match exists to catch).
+
+## Deliverable
+A code change to `Test-WingetSourceHealth`'s corruption check (`WingetAppSetup/Private/
+WingetBootstrap.ps1`, line 117) that checks the `0x8a15000f` case via its numeric exit code
+(`-1978335217`) where winget actually returns it, while keeping — and clearly commenting as
+locale-fragile-but-necessary — a reduced prose-matching fallback only for the specific
+scenario this exists to catch (exit code 0 despite corrupted output), plus new/updated Pester
+coverage isolating that scenario, a regenerated `winget-app-install.ps1`, and a `CHANGELOG.md`
+entry.
+
+## Requirements
+- R1. When `winget search` returns a nonzero exit code that corresponds to the known
+  `0x8a15000f`/`-1978335217` corruption signature, the function must classify the source as
+  not-functional via the numeric exit code check, without needing the prose match to fire.
+  [verify: unit test mocks `$LASTEXITCODE` to `-1978335217` with output text NOT matching the
+  existing prose regex, and asserts `Test-WingetSourceHealth` still reports `Functional = $false`]
+- R2. The existing scenario the prose match specifically exists for — corrupted-looking output text
+  with exit code 0 — must continue to be caught. [verify: unit test mocks exit code 0 with output
+  matching the corruption phrases, asserts `Functional = $false`, isolating this from the
+  already-covered "nonzero exit + corrupted text" combination]
+- R3. A code comment must explain why prose matching is retained for this one case (winget
+  reportedly returns success despite corruption in some versions) and flag it as locale-sensitive,
+  mirroring the existing locale-dependency acknowledgment pattern in
+  `winget-app-uninstall.ps1:48`. [verify: code review of the comment]
+- R4. Existing test coverage in `tests/WingetBootstrap.Tests.ps1` continues to pass; add the new
+  isolated test cases from R1/R2 rather than replacing existing ones. [verify: `Invoke-Pester
+  ./tests/WingetBootstrap.Tests.ps1`, existing test names all still present and passing]
+- R5. `winget-app-install.ps1` is regenerated and `pwsh -File ./build/Build-WingetInstallScript.ps1
+  -Check` passes. [verify: run the command, exit code 0]
+- R6. The full Pester suite passes on Pester 6.x with zero new failures and no change to the
+  pre-existing skip count. [verify: `Invoke-Pester ./tests`, compare before/after]
+
+## Out of scope
+- Do not remove prose matching entirely — the verifier confirmed at least one real scenario (exit 0
+  despite corruption) where text is the only available signal; this spec reduces reliance on prose,
+  it does not eliminate it.
+- Do not change `Test-WingetSourceHealth`'s two-step (Listed/Functional) structure or its `-Quiet`
+  parameter behavior.
+- Do not touch the `winget source list` "Listed" check (lines 98-105) — this spec is scoped to the
+  "Functional" check only.
+
+## Constraints
+- PowerShell 7+ syntax; module source only, never hand-edit `winget-app-install.ps1`.
+- Use the exact numeric constant already verified: `-1978335217` for `0x8a15000f`; do not
+  reintroduce it as a magic number without a comment tying it to the hex HRESULT.
+- Tests must mock all external winget calls per repo CLAUDE.md.
+- Rebuild via `build/Build-WingetInstallScript.ps1` and commit the regenerated file alongside the
+  module change.
+
+## Acceptance rubric
+- C1 (from R1): PASS iff a test proves the `-1978335217` exit code alone (no prose match needed)
+  correctly reports not-functional.
+- C2 (from R2): PASS iff a test proves the exit-0-with-corrupted-text case is still caught.
+- C3 (from R3): PASS iff a comment documents the retained prose match's purpose and locale
+  sensitivity.
+- C4 (from R4): PASS iff all pre-existing `tests/WingetBootstrap.Tests.ps1` tests still pass.
+- C5 (from R5): PASS iff `build/Build-WingetInstallScript.ps1 -Check` exits 0 after the change.
+- C6 (from R6): PASS iff the full Pester suite shows 0 new failures and the same skip count.
+- C-final: PASS iff a domain expert reviewing this artifact would accept it without substantive
+  changes.
+
+## Open questions
+(none)

--- a/specs/winget-source-update-no-timeout.md
+++ b/specs/winget-source-update-no-timeout.md
@@ -1,0 +1,93 @@
+# Spec: Pre-elevation `winget source update` needs the same timeout guard as its sibling probe
+
+## Goal
+The pre-elevation `winget source update` call in `Invoke-WingetInstall` can no longer hang the
+entire run indefinitely on a corrupted/unreachable winget source — it must time out and continue,
+the same way the module's own `Invoke-WingetSourceProbe` already does for the identical command.
+
+## Context
+`WingetAppSetup/Public/Install.ps1` (currently line 73, inside `Invoke-WingetInstall`, before
+elevation) runs:
+
+```powershell
+Start-Process -FilePath 'winget' -ArgumentList 'source', 'update', '--name', 'winget', '--disable-interactivity' -Wait -NoNewWindow
+```
+
+with no `-PassThru`, no exit-code check, and — the actual bug — no timeout. `-Wait` blocks the
+calling thread until the child process exits on its own, however long that takes.
+
+`WingetAppSetup/Private/WingetBootstrap.ps1`'s `Invoke-WingetSourceProbe` (lines 27-67) runs the
+**exact same command** (`winget source update --name winget --disable-interactivity`) but wraps it
+with `-PassThru`, redirected output, and a `$TimeoutSeconds` (default 120) `WaitForExit`/`Kill()`
+guard, specifically because — per this repo's own history (issue #177, and the general
+timeout-guard pattern documented across `CHANGELOG.md` for issue #120 and elsewhere) — this class
+of winget call is known to hang.
+
+Verified via direct read and an independent verifier agent (CONFIRMED, full-repo review,
+2026-07-16): no `$ErrorActionPreference = 'Stop'` is set anywhere in this scope (confirmed by
+grepping the whole repo), so a "winget not found" failure at this call site is a non-terminating
+error that lets execution continue into `Test-AndInstallWinget` (which installs winget when
+missing) — that part is low severity and out of scope here. The **timeout gap** is the real,
+higher-severity issue: on a healthy winget source this call returns quickly, but on a broken one it
+can block the whole script forever, before elevation, before any of the timeout-guarded checks
+later in the pipeline ever run.
+
+This repo's convention: the module is the source of truth; `winget-app-install.ps1` is generated
+and must never be hand-edited. Tests use Pester 6.x, mock every external call (including
+`Start-Process`), and use unconditional `Mock` in `BeforeEach`.
+
+## Deliverable
+A code change to `WingetAppSetup/Public/Install.ps1`'s `Invoke-WingetInstall` (the call currently at
+line 73), reusing or mirroring `Invoke-WingetSourceProbe`'s timeout-guard pattern from
+`WingetAppSetup/Private/WingetBootstrap.ps1`, plus new/updated Pester coverage, a regenerated
+`winget-app-install.ps1`, and a `CHANGELOG.md` entry.
+
+## Requirements
+- R1. The pre-elevation `winget source update` call must have a bounded wait: if the process has
+  not exited within a fixed timeout (recommend reusing `Invoke-WingetSourceProbe`'s existing
+  120-second default rather than inventing a new number), the process is killed and execution
+  continues rather than blocking forever. [verify: unit test mocks the underlying process object
+  such that `WaitForExit` returns `$false` (simulating a hang), and asserts the function returns /
+  continues within the test's synchronous execution rather than blocking, and that a `Kill()`-style
+  call was invoked]
+- R2. On a normal (non-hanging) run, behavior must be observably unchanged: the call still runs
+  before elevation, still updates the winget source in the user's context, still uses
+  `--disable-interactivity`. [verify: existing/updated test asserts the winget command is invoked
+  with the same arguments as before the change]
+- R3. Prefer reusing `Invoke-WingetSourceProbe` directly (it already does exactly this, in the same
+  module) over duplicating the timeout-guard logic a third time; if reuse isn't feasible, the
+  reviewer must be able to see why in code comments. [verify: code review — either the call site
+  now calls `Invoke-WingetSourceProbe`, or a comment explains why a separate implementation was
+  necessary]
+- R4. `winget-app-install.ps1` is regenerated and `pwsh -File ./build/Build-WingetInstallScript.ps1
+  -Check` passes. [verify: run the command, exit code 0]
+- R5. The full Pester suite passes on Pester 6.x with zero new failures and no change to the
+  pre-existing skip count. [verify: `Invoke-Pester ./tests`, compare before/after]
+
+## Out of scope
+- Do not change `Invoke-WingetSourceProbe` itself unless R3 requires extracting a shared helper —
+  if you do extract one, keep its behavior identical to the current `Invoke-WingetSourceProbe`.
+- Do not add retry/backoff logic here — a timeout-and-continue is sufficient; this call was already
+  best-effort (its exit code was never checked before this fix either).
+- Do not change any other winget call site in the module.
+
+## Constraints
+- PowerShell 7+ syntax; module source only, never hand-edit `winget-app-install.ps1`.
+- Match the existing timeout-guard idiom already used in this module (`Start-Process -PassThru`,
+  `WaitForExit(ms)`, `Kill()` in a try/catch) rather than inventing a new pattern.
+- Tests must mock all external process calls per repo CLAUDE.md.
+- Rebuild via `build/Build-WingetInstallScript.ps1` and commit the regenerated file alongside the
+  module change.
+
+## Acceptance rubric
+- C1 (from R1): PASS iff a test proves a simulated hang on this call site is bounded (killed after
+  timeout) rather than blocking indefinitely.
+- C2 (from R2): PASS iff a normal-path test proves the same winget arguments are still passed.
+- C3 (from R3): PASS iff the change reuses `Invoke-WingetSourceProbe` or documents why not.
+- C4 (from R4): PASS iff `build/Build-WingetInstallScript.ps1 -Check` exits 0 after the change.
+- C5 (from R5): PASS iff the full Pester suite shows 0 new failures and the same skip count.
+- C-final: PASS iff a domain expert reviewing this artifact would accept it without substantive
+  changes.
+
+## Open questions
+(none)


### PR DESCRIPTION
Ref #232 #233 #234 #235 #236 #237 #238 #239 #240 #241

## Summary

Binary-acceptance-criteria specs (via `/blueprint`) for each of the 10 findings from the
2026-07-16 full-repo review, ready to run through the `forge` generator/evaluator loop:

- `specs/whatif-ignored-iex-elevation.md` — #232
- `specs/winget-source-update-no-timeout.md` — #233
- `specs/install-powershell-latest-verify-timeout.md` — #234
- `specs/package-id-regex-validation.md` — #235
- `specs/build-guard-indirect-dispatch.md` — #236
- `specs/retry-pass-failure-message-mislabel.md` — #237
- `specs/remove-dead-environment-path-code.md` — #238
- `specs/consolidate-admin-check-helper.md` — #239
- `specs/consolidate-winget-common-args.md` — #240
- `specs/winget-source-health-exit-code-classification.md` — #241

No code changes — docs only.

## Test plan
- [x] No source files touched; existing Pester/build CI is expected to pass unmodified