### PR TITLE
fix: retry Install-WingetPackage on a transient winget.exe launch exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `Install-WingetPackage` losing its whole retry budget to a single Start-Process launch
+  failure (issue #253): on a scheduled E2E run, `winget.exe` was transiently inaccessible
+  (`Start-Process` threw "This command cannot be run due to the error: The file cannot be
+  accessed by the system." — Win32 `ERROR_CANT_ACCESS_FILE`, the classic AV-scan/AppX
+  registration-race symptom) for every app that actually needed installing, and every one of them
+  failed both the first pass and the one-shot app-level retry with zero delay in between. Because
+  the exception is thrown before `Start-Process` ever returns a process object, it previously
+  bypassed the function's exit-code-based backoff loop entirely on the very first attempt.
+  `Install-WingetPackage` now wraps the `Start-Process` call in a `try`/`catch`: this specific,
+  known-transient launch exception (plus its `ERROR_SHARING_VIOLATION` sibling) is retried with
+  the same increasing backoff already used for the `0x80073d19` session error, consuming the same
+  `MaxAttempts` budget and surfaced in the result as a new `LaunchErrorExhausted` flag
+  (`ExitCode` is `$null` in that case, since no process ever ran); `Format-InstallFailureReason`
+  reports it distinctly instead of a fabricated exit code. Any other launch exception (e.g.
+  winget genuinely missing) is re-thrown unchanged. Covered by new Pester coverage in
+  `tests/WingetCore.Tests.ps1` and `tests/Install.Tests.ps1`.
 - Fixed `-WhatIf` being ignored on the IEX/remote path when the invoking session is not
   administrator: `Invoke-WingetInstall`'s non-admin `else` branch for `Test-IsRunningLocally`
   returning `$false` (`WingetAppSetup/Public/Install.ps1`, every `irm <url> | iex` run, since there

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`ExitCode` is `$null` in that case, since no process ever ran); `Format-InstallFailureReason`
   reports it distinctly instead of a fabricated exit code. Any other launch exception (e.g.
   winget genuinely missing) is re-thrown unchanged. Covered by new Pester coverage in
-  `tests/WingetCore.Tests.ps1` and `tests/Install.Tests.ps1`.
+  `tests/WingetCore.Tests.ps1` and `tests/Install.Tests.ps1`
+  ([#257](https://github.com/J-MaFf/winget-app-setup/pull/257)).
 - Fixed `-WhatIf` being ignored on the IEX/remote path when the invoking session is not
   administrator: `Invoke-WingetInstall`'s non-admin `else` branch for `Test-IsRunningLocally`
   returning `$false` (`WingetAppSetup/Public/Install.ps1`, every `irm <url> | iex` run, since there

--- a/WingetAppSetup/Private/FailureReporting.ps1
+++ b/WingetAppSetup/Private/FailureReporting.ps1
@@ -64,6 +64,11 @@ function Format-InstallFailureReason {
         if ($InstallResult.ContainsKey('SessionErrorExhausted') -and $InstallResult.SessionErrorExhausted) {
             $detailParts += 'session error 0x80073D19 persisted through every retry'
         }
+        if ($InstallResult.ContainsKey('LaunchErrorExhausted') -and $InstallResult.LaunchErrorExhausted) {
+            # issue #253: Start-Process could not launch winget.exe (transient file lock) on every
+            # attempt, so no install ever actually ran.
+            $detailParts += 'winget executable was transiently inaccessible through every retry'
+        }
     }
 
     if ($detailParts.Count -gt 0) {

--- a/WingetAppSetup/Public/WingetCore.ps1
+++ b/WingetAppSetup/Public/WingetCore.ps1
@@ -283,6 +283,20 @@ function Initialize-WingetSourcesForUser {
     user; the session error is identified purely from the exit code, which winget reports as
     0x80073d19 for this failure.
 
+    Start-Process can also fail to launch winget.exe at all, throwing a terminating exception
+    ("This command cannot be run due to the error: The file cannot be accessed by the system.",
+    Win32 ERROR_CANT_ACCESS_FILE / 1920, or the sibling ERROR_SHARING_VIOLATION "being used by
+    another process") instead of returning a process object with an exit code. This happens when
+    winget.exe's own file is transiently locked — e.g. Windows Defender real-time scanning it, or
+    an AppX package-registration race right after Repair-WinGetPackageManager runs. Because that
+    exception is thrown before a process object ever exists, it used to bypass the exit-code-based
+    retry loop below entirely: on a GitHub-hosted E2E runner this was observed to fail every
+    install in a run, surviving even the caller's separate one-shot retry pass, because neither
+    layer paused before retrying (issue #253). The Start-Process call is now wrapped so this
+    specific class of launch exception is retried with the same backoff as the session error,
+    instead of propagating out of the function on the first attempt. Any other exception (e.g.
+    winget genuinely missing) is re-thrown unchanged so it is not silently swallowed.
+
     Installs prefer `--scope machine` (issue #159): user-scope installs land in the elevated
     account's profile rather than the logged-on user's, and packages that ship both MSIX and MSI
     installers (e.g. Microsoft.PowerShell) resolve at user scope to the MSIX — whose per-user AppX
@@ -302,11 +316,13 @@ function Initialize-WingetSourcesForUser {
 .PARAMETER InitialDelaySeconds
     Seconds to wait before the first retry; the wait doubles on each subsequent retry. Default 5.
 .RETURNS
-    [hashtable] @{ ExitCode = <int>; Attempts = <int>; SessionErrorExhausted = <bool>; MachineScopeFellBack = <bool> }
+    [hashtable] @{ ExitCode = <int|$null>; Attempts = <int>; SessionErrorExhausted = <bool>; MachineScopeFellBack = <bool>; LaunchErrorExhausted = <bool> }
     SessionErrorExhausted is True only when every attempt failed with the session error.
     MachineScopeFellBack is True when the package had no machine-scope installer and the install
     was retried at winget's default scope. Attempts counts install attempts at the finally
     selected scope; the one-time scope fallback does not consume a session-error attempt.
+    LaunchErrorExhausted is True only when every attempt failed to launch winget.exe at all (issue
+    #253); ExitCode is $null in that case, since no process ever ran to report one.
 #>
 function Install-WingetPackage {
     param (
@@ -329,12 +345,19 @@ function Install-WingetPackage {
     # 0x8A150010 (APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER) as a signed Int32: returned when
     # the --scope machine requirement filters out every installer in the package's manifest.
     $noApplicableInstallerExitCode = -1978335216
+    # Text fragments of the Win32 errors Start-Process surfaces as a terminating exception when it
+    # cannot even launch winget.exe (issue #253): ERROR_CANT_ACCESS_FILE (1920, "The file cannot be
+    # accessed by the system.") and the sibling ERROR_SHARING_VIOLATION ("...being used by another
+    # process."). Matched case-insensitively against the exception message; anything else is a real
+    # failure (e.g. winget missing from PATH) and is re-thrown rather than retried.
+    $transientLaunchErrorPattern = 'cannot be accessed by the system|being used by another process'
 
     $attempt = 0
     $delay = $InitialDelaySeconds
     $exitCode = 0
     $useMachineScope = $true
     $machineScopeFellBack = $false
+    $launchErrorExhausted = $false
 
     while ($attempt -lt $MaxAttempts) {
         $attempt++
@@ -357,8 +380,31 @@ function Install-WingetPackage {
             $installArgs += @('--installer-type', $InstallerType)
         }
 
-        $proc = Start-Process -FilePath 'winget' -ArgumentList $installArgs -NoNewWindow -Wait -PassThru
-        $exitCode = $proc.ExitCode
+        try {
+            $proc = Start-Process -FilePath 'winget' -ArgumentList $installArgs -NoNewWindow -Wait -PassThru
+            $exitCode = $proc.ExitCode
+            $launchErrorExhausted = $false
+        }
+        catch {
+            if ($_.Exception.Message -notmatch $transientLaunchErrorPattern) {
+                # Not a known-transient launch failure (e.g. winget genuinely missing) — preserve
+                # the prior behavior of letting it propagate instead of masking a real problem as
+                # an ordinary install failure.
+                throw
+            }
+
+            $launchErrorExhausted = $true
+            if ($attempt -lt $MaxAttempts) {
+                Write-WarningMessage "Could not launch winget for $PackageId - its executable appears transiently locked ($($_.Exception.Message)). Waiting ${delay}s before retry $($attempt + 1) of ${MaxAttempts}..."
+                Start-Sleep -Seconds $delay
+                $delay = $delay * 2
+                continue
+            }
+
+            Write-WarningMessage "Still unable to launch winget for $PackageId after ${MaxAttempts} attempts (executable transiently inaccessible on every attempt)."
+            $exitCode = $null
+            break
+        }
 
         # No installer matched the machine-scope requirement (e.g. MSIX-only packages such as
         # Microsoft.WindowsTerminal, which only install per-user). Fall back to winget's default
@@ -393,6 +439,7 @@ function Install-WingetPackage {
         Attempts              = $attempt
         SessionErrorExhausted = ($exitCode -eq $sessionLogoffExitCode)
         MachineScopeFellBack  = $machineScopeFellBack
+        LaunchErrorExhausted  = $launchErrorExhausted
     }
 }
 

--- a/tests/Install.Tests.ps1
+++ b/tests/Install.Tests.ps1
@@ -765,6 +765,16 @@ Describe 'Format-InstallFailureReason (issue #189)' {
             $reason | Should -Match 'winget exit 0x80073D19'
             $reason | Should -Match 'session error 0x80073D19 persisted through every retry'
         }
+
+        It 'Calls out an exhausted transient launch failure without a fabricated exit code (issue #253)' {
+            $installResult = @{ ExitCode = $null; Attempts = 3; SessionErrorExhausted = $false; MachineScopeFellBack = $false; LaunchErrorExhausted = $true }
+
+            $reason = Format-InstallFailureReason -FailureReason 'VerifyNotFound' -InstallResult $installResult
+
+            $reason | Should -Not -Match 'winget exit'
+            $reason | Should -Match '3 attempts'
+            $reason | Should -Match 'winget executable was transiently inaccessible through every retry'
+        }
     }
 
     Context 'With a custom installer result shape (ExitCode/Installed only)' {

--- a/tests/WingetCore.Tests.ps1
+++ b/tests/WingetCore.Tests.ps1
@@ -584,6 +584,78 @@ Describe 'Install-WingetPackage (0x80073d19 session-error backoff)' {
     }
 }
 
+Describe 'Install-WingetPackage (transient launch-exception backoff, issue #253)' {
+    BeforeEach {
+        Mock Write-Host { }
+        Mock Write-WarningMessage { }
+        Mock Write-Info { }
+        # Never actually wait during tests; the backoff is verified via Should -Invoke.
+        Mock Start-Sleep { }
+    }
+
+    It 'Retries with backoff and recovers when Start-Process throws a transient file-lock exception' {
+        $script:callIndex = 0
+        Mock Start-Process {
+            $script:callIndex++
+            if ($script:callIndex -eq 1) {
+                throw 'This command cannot be run due to the error: The file cannot be accessed by the system.'
+            }
+            [pscustomobject]@{ ExitCode = 0 }
+        }
+
+        $result = Install-WingetPackage -PackageId 'Klocman.BulkCrapUninstaller' -MaxAttempts 3 -InitialDelaySeconds 1
+
+        $result.ExitCode | Should -Be 0
+        $result.Attempts | Should -Be 2
+        $result.LaunchErrorExhausted | Should -Be $false
+        Should -Invoke Start-Process -Times 2 -Exactly
+        Should -Invoke Start-Sleep -Times 1 -Exactly
+    }
+
+    It 'Also retries the sibling sharing-violation launch exception' {
+        $script:callIndex = 0
+        Mock Start-Process {
+            $script:callIndex++
+            if ($script:callIndex -eq 1) {
+                throw 'This command cannot be run due to the error: The process cannot access the file because it is being used by another process.'
+            }
+            [pscustomobject]@{ ExitCode = 0 }
+        }
+
+        $result = Install-WingetPackage -PackageId 'Microsoft.WindowsTerminal' -MaxAttempts 3 -InitialDelaySeconds 1
+
+        $result.ExitCode | Should -Be 0
+        $result.LaunchErrorExhausted | Should -Be $false
+        Should -Invoke Start-Process -Times 2 -Exactly
+    }
+
+    It 'Exhausts MaxAttempts when winget.exe stays transiently inaccessible, returning a null ExitCode' {
+        Mock Start-Process {
+            throw 'This command cannot be run due to the error: The file cannot be accessed by the system.'
+        }
+
+        $result = Install-WingetPackage -PackageId 'Microsoft.PowerShell' -MaxAttempts 3 -InitialDelaySeconds 1
+
+        $result.ExitCode | Should -Be $null
+        $result.Attempts | Should -Be 3
+        $result.LaunchErrorExhausted | Should -Be $true
+        Should -Invoke Start-Process -Times 3 -Exactly
+        # Sleeps between attempts only (1->2 and 2->3), never after the final attempt.
+        Should -Invoke Start-Sleep -Times 2 -Exactly
+    }
+
+    It 'Re-throws an unrelated Start-Process exception instead of retrying it' {
+        Mock Start-Process {
+            throw 'The system cannot find the file specified.'
+        }
+
+        { Install-WingetPackage -PackageId 'Test.App' -MaxAttempts 3 -InitialDelaySeconds 1 } | Should -Throw '*cannot find the file specified*'
+
+        Should -Invoke Start-Process -Times 1 -Exactly
+        Should -Invoke Start-Sleep -Times 0 -Exactly
+    }
+}
+
 Describe 'Test-WingetPackageInstalled (timeout support, issue #188)' {
     BeforeEach {
         Mock Write-Host { }

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -58,12 +58,12 @@ param (
 # This script is assembled from the WingetAppSetup module by build/Build-WingetInstallScript.ps1.
 # Edit the function source under WingetAppSetup/Public and WingetAppSetup/Private, then re-run the
 # build to regenerate this file. See readme.md ("Project layout") for details.
-# Build id: 1.0.0+9f271116 (module version + SHA256 fragment of the function content; issue #189).
+# Build id: 1.0.0+b25dab43 (module version + SHA256 fragment of the function content; issue #189).
 # ------------------------------------------------------------------------------------------------
 
 # Content-derived build identity, logged at startup so a transcript from a remote machine
 # identifies exactly which installer build produced it (issue #189).
-$script:InstallerBuildId = '1.0.0+9f271116'
+$script:InstallerBuildId = '1.0.0+b25dab43'
 
 # ------------------------------------------------Functions------------------------------------------------
 
@@ -250,6 +250,11 @@ function Format-InstallFailureReason {
         }
         if ($InstallResult.ContainsKey('SessionErrorExhausted') -and $InstallResult.SessionErrorExhausted) {
             $detailParts += 'session error 0x80073D19 persisted through every retry'
+        }
+        if ($InstallResult.ContainsKey('LaunchErrorExhausted') -and $InstallResult.LaunchErrorExhausted) {
+            # issue #253: Start-Process could not launch winget.exe (transient file lock) on every
+            # attempt, so no install ever actually ran.
+            $detailParts += 'winget executable was transiently inaccessible through every retry'
         }
     }
 
@@ -3172,6 +3177,20 @@ function Initialize-WingetSourcesForUser {
     user; the session error is identified purely from the exit code, which winget reports as
     0x80073d19 for this failure.
 
+    Start-Process can also fail to launch winget.exe at all, throwing a terminating exception
+    ("This command cannot be run due to the error: The file cannot be accessed by the system.",
+    Win32 ERROR_CANT_ACCESS_FILE / 1920, or the sibling ERROR_SHARING_VIOLATION "being used by
+    another process") instead of returning a process object with an exit code. This happens when
+    winget.exe's own file is transiently locked — e.g. Windows Defender real-time scanning it, or
+    an AppX package-registration race right after Repair-WinGetPackageManager runs. Because that
+    exception is thrown before a process object ever exists, it used to bypass the exit-code-based
+    retry loop below entirely: on a GitHub-hosted E2E runner this was observed to fail every
+    install in a run, surviving even the caller's separate one-shot retry pass, because neither
+    layer paused before retrying (issue #253). The Start-Process call is now wrapped so this
+    specific class of launch exception is retried with the same backoff as the session error,
+    instead of propagating out of the function on the first attempt. Any other exception (e.g.
+    winget genuinely missing) is re-thrown unchanged so it is not silently swallowed.
+
     Installs prefer `--scope machine` (issue #159): user-scope installs land in the elevated
     account's profile rather than the logged-on user's, and packages that ship both MSIX and MSI
     installers (e.g. Microsoft.PowerShell) resolve at user scope to the MSIX — whose per-user AppX
@@ -3191,11 +3210,13 @@ function Initialize-WingetSourcesForUser {
 .PARAMETER InitialDelaySeconds
     Seconds to wait before the first retry; the wait doubles on each subsequent retry. Default 5.
 .RETURNS
-    [hashtable] @{ ExitCode = <int>; Attempts = <int>; SessionErrorExhausted = <bool>; MachineScopeFellBack = <bool> }
+    [hashtable] @{ ExitCode = <int|$null>; Attempts = <int>; SessionErrorExhausted = <bool>; MachineScopeFellBack = <bool>; LaunchErrorExhausted = <bool> }
     SessionErrorExhausted is True only when every attempt failed with the session error.
     MachineScopeFellBack is True when the package had no machine-scope installer and the install
     was retried at winget's default scope. Attempts counts install attempts at the finally
     selected scope; the one-time scope fallback does not consume a session-error attempt.
+    LaunchErrorExhausted is True only when every attempt failed to launch winget.exe at all (issue
+    #253); ExitCode is $null in that case, since no process ever ran to report one.
 #>
 function Install-WingetPackage {
     param (
@@ -3218,12 +3239,19 @@ function Install-WingetPackage {
     # 0x8A150010 (APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER) as a signed Int32: returned when
     # the --scope machine requirement filters out every installer in the package's manifest.
     $noApplicableInstallerExitCode = -1978335216
+    # Text fragments of the Win32 errors Start-Process surfaces as a terminating exception when it
+    # cannot even launch winget.exe (issue #253): ERROR_CANT_ACCESS_FILE (1920, "The file cannot be
+    # accessed by the system.") and the sibling ERROR_SHARING_VIOLATION ("...being used by another
+    # process."). Matched case-insensitively against the exception message; anything else is a real
+    # failure (e.g. winget missing from PATH) and is re-thrown rather than retried.
+    $transientLaunchErrorPattern = 'cannot be accessed by the system|being used by another process'
 
     $attempt = 0
     $delay = $InitialDelaySeconds
     $exitCode = 0
     $useMachineScope = $true
     $machineScopeFellBack = $false
+    $launchErrorExhausted = $false
 
     while ($attempt -lt $MaxAttempts) {
         $attempt++
@@ -3246,8 +3274,31 @@ function Install-WingetPackage {
             $installArgs += @('--installer-type', $InstallerType)
         }
 
-        $proc = Start-Process -FilePath 'winget' -ArgumentList $installArgs -NoNewWindow -Wait -PassThru
-        $exitCode = $proc.ExitCode
+        try {
+            $proc = Start-Process -FilePath 'winget' -ArgumentList $installArgs -NoNewWindow -Wait -PassThru
+            $exitCode = $proc.ExitCode
+            $launchErrorExhausted = $false
+        }
+        catch {
+            if ($_.Exception.Message -notmatch $transientLaunchErrorPattern) {
+                # Not a known-transient launch failure (e.g. winget genuinely missing) — preserve
+                # the prior behavior of letting it propagate instead of masking a real problem as
+                # an ordinary install failure.
+                throw
+            }
+
+            $launchErrorExhausted = $true
+            if ($attempt -lt $MaxAttempts) {
+                Write-WarningMessage "Could not launch winget for $PackageId - its executable appears transiently locked ($($_.Exception.Message)). Waiting ${delay}s before retry $($attempt + 1) of ${MaxAttempts}..."
+                Start-Sleep -Seconds $delay
+                $delay = $delay * 2
+                continue
+            }
+
+            Write-WarningMessage "Still unable to launch winget for $PackageId after ${MaxAttempts} attempts (executable transiently inaccessible on every attempt)."
+            $exitCode = $null
+            break
+        }
 
         # No installer matched the machine-scope requirement (e.g. MSIX-only packages such as
         # Microsoft.WindowsTerminal, which only install per-user). Fall back to winget's default
@@ -3282,6 +3333,7 @@ function Install-WingetPackage {
         Attempts              = $attempt
         SessionErrorExhausted = ($exitCode -eq $sessionLogoffExitCode)
         MachineScopeFellBack  = $machineScopeFellBack
+        LaunchErrorExhausted  = $launchErrorExhausted
     }
 }
 


### PR DESCRIPTION
Fixes #253

## Root cause: 2026-07-20 run (Start-Process file-lock)

That run failed every app that actually needed installing
(`Klocman.BulkCrapUninstaller`, `Microsoft.PowerShell`,
`Microsoft.WindowsTerminal`) with repeated:

```
TerminatingError(Start-Process): "This command cannot be run due to the error: The file cannot be accessed by the system."
```

That message is Win32 `ERROR_CANT_ACCESS_FILE` (1920) — the classic
symptom of `winget.exe`'s own file being transiently locked (Windows
Defender real-time scanning it, or an AppX package-registration race
right after `Repair-WinGetPackageManager` runs).

`Start-Process` throws this as a **terminating .NET exception before it
ever returns a process object**. `Install-WingetPackage` already has a
purpose-built backoff-retry loop (up to `MaxAttempts`, doubling delay) —
but it's keyed entirely on `$proc.ExitCode`, so an exception thrown
before that assignment skips the loop's retry logic completely on the
very first attempt. The only remaining safety net was
`Invoke-WingetInstall`'s one-shot, zero-delay app-level retry pass, which
hit the same still-locked file a few seconds later and failed again —
exactly what the transcript shows for all three apps.

### Fix

`Install-WingetPackage`'s `Start-Process` call is now wrapped in a
`try`/`catch`. This specific, known-transient launch exception (plus its
sibling `ERROR_SHARING_VIOLATION`, "being used by another process") is
retried with the same increasing backoff already used for the
`0x80073d19` session error, consuming the same `MaxAttempts` budget. Any
other launch exception (e.g. winget genuinely missing from `PATH`) is
re-thrown unchanged so a real problem is never silently swallowed as an
ordinary install failure.

The result hashtable gains a `LaunchErrorExhausted` flag (`ExitCode` is
`$null` in that case, since no process ever ran).
`Format-InstallFailureReason` reports it with a clear message instead of
fabricating a hex exit code from `$null`.

## Root cause: 2026-07-21 run (Google.GoogleDrive 404) — no code change

`Google.GoogleDrive` failed with `winget exit 0x80190194` — winget's own
"Not found (404)" on the installer download URL. I verified
`winget source update --name winget` already runs unconditionally before
every install pass, via `Initialize-WingetSourcesForUser` →
`Invoke-WingetSourceProbe` (`WingetAppSetup/Public/WingetCore.ps1` /
`WingetAppSetup/Private/WingetBootstrap.ps1`) — so a stale local source
index is not the cause. The default `winget` source is REST-backed:
`source update` refreshes the local package-name index, but a
package's manifest data (including `InstallerUrl`) is resolved live per
install call against Microsoft's community-repository service, not
served from that local index. A URL 404 there means the manifest
published upstream currently points at a dead URL — genuinely outside
this repo's control, and re-running `source update` wouldn't have
changed the outcome. Treating this as one-off external flakiness; no
code change accompanies it.

## Testing

- `Invoke-Pester ./tests` — 312 passed, 0 failed, 3 skipped (pre-existing,
  unrelated)
- `pwsh -File ./build/Build-WingetInstallScript.ps1 -Check` — drift guard
  passes (installer regenerated and committed)
- New coverage in `tests/WingetCore.Tests.ps1` (backoff recovery on the
  file-lock message, the sharing-violation sibling message, exhaustion
  producing a null `ExitCode`, and re-throw of an unrelated exception)
  and `tests/Install.Tests.ps1` (`Format-InstallFailureReason` wording
  for the new flag)