### PR TITLE
fix: survive a broken winget alias by re-resolving the executable and widening launch retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,8 +88,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   package registers; (2) `Test-WingetPackageInstalled`'s timeout-mode check retries once through
   the same alias bypass instead of silently swallowing the launch exception and misreporting an
   installed package as missing — which is exactly how the already-installed Windows Terminal got
-  classified as a failed install. Covered by new Pester coverage in
-  `tests/WingetLaunchResilience.Tests.ps1` and `tests/WingetCore.Tests.ps1`.
+  classified as a failed install. A launch failure of a concrete bypass path is always retried
+  (even `ERROR_FILE_NOT_FOUND`, since the resolved package version can be deleted mid-backoff by
+  the completing upgrade), while a non-transient failure of the plain `winget` alias still
+  re-throws so a genuinely missing winget is not masked. Covered by new Pester coverage in
+  `tests/WingetLaunchResilience.Tests.ps1` and `tests/WingetCore.Tests.ps1`
+  ([#259](https://github.com/J-MaFf/winget-app-setup/pull/259)).
 - Fixed `Install-WingetPackage` losing its whole retry budget to a single Start-Process launch
   failure (issue #253): on a scheduled E2E run, `winget.exe` was transiently inaccessible
   (`Start-Process` threw "This command cannot be run due to the error: The file cannot be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the winget launch retry never recovering when the `winget.exe` app-execution alias breaks
+  mid-run (issue #258): E2E run 30253761253's second (idempotence) pass failed
+  `Microsoft.WindowsTerminal` — an app that was already installed — because a background
+  Winget-AutoUpdate run (started by the installer itself via `RUN_WAU=YES` seconds earlier, and
+  capable of upgrading App Installer/winget) invalidated the per-user
+  `Microsoft.DesktopAppInstaller` alias for longer than the entire 15s retry window the #253 fix
+  covered, so every `Start-Process winget` — pre-check, three install attempts, verify, and the
+  whole retry pass — threw `ERROR_CANT_ACCESS_FILE` against the same broken alias. Two changes in
+  `WingetAppSetup/Public/WingetCore.ps1` plus the new private helper
+  `WingetAppSetup/Private/WingetLaunchResilience.ps1`: (1) launch failures now have their own
+  retry budget in `Install-WingetPackage` (`MaxLaunchAttempts`, default 5, doubling backoff
+  5s+10s+20s+40s = 75s — sized to outlast an App Installer re-registration; a failed launch no
+  longer consumes an install attempt since no process ran, and the result gains a
+  `LaunchAttempts` count), and each launch retry re-resolves the executable via
+  `Resolve-WingetExecutable -BypassAlias`, launching the registered DesktopAppInstaller package's
+  own `winget.exe` directly instead of the broken alias so the retry converges as soon as the new
+  package registers; (2) `Test-WingetPackageInstalled`'s timeout-mode check retries once through
+  the same alias bypass instead of silently swallowing the launch exception and misreporting an
+  installed package as missing — which is exactly how the already-installed Windows Terminal got
+  classified as a failed install. Covered by new Pester coverage in
+  `tests/WingetLaunchResilience.Tests.ps1` and `tests/WingetCore.Tests.ps1`.
 - Fixed `Install-WingetPackage` losing its whole retry budget to a single Start-Process launch
   failure (issue #253): on a scheduled E2E run, `winget.exe` was transiently inaccessible
   (`Start-Process` threw "This command cannot be run due to the error: The file cannot be

--- a/STATUS.md
+++ b/STATUS.md
@@ -183,7 +183,7 @@ Pester installs persist across runs there ([#161](https://github.com/J-MaFf/wing
 
 | Issue | Description | Status |
 |-------|-------------|--------|
-| [#258](https://github.com/J-MaFf/winget-app-setup/issues/258) | E2E install run failed: winget alias inaccessible through every launch retry (WAU/App Installer upgrade race) | In review |
+| [#258](https://github.com/J-MaFf/winget-app-setup/issues/258) | E2E install run failed: winget alias inaccessible through every launch retry (WAU/App Installer upgrade race) | In review — PR [#259](https://github.com/J-MaFf/winget-app-setup/pull/259) |
 | [#225](https://github.com/J-MaFf/winget-app-setup/issues/225) | Bootstrap PowerShell 7 from Windows PowerShell 5.1 instead of failing fast | In review — PR [#228](https://github.com/J-MaFf/winget-app-setup/pull/228) |
 
 ## Natural Next Steps

--- a/STATUS.md
+++ b/STATUS.md
@@ -12,7 +12,17 @@ scripts target **Windows PowerShell / PowerShell 7 on Windows**; they cannot run
 Linux or macOS because they depend on `winget`, the `Microsoft.WinGet.Client` module, and
 Windows-only cmdlets.
 
-## Current State — 2026-07-10
+## Current State — 2026-08-09
+
+In review: **winget launch resilience while the app-execution alias is broken**
+([#258](https://github.com/J-MaFf/winget-app-setup/issues/258)) — the 2026-07-27 scheduled E2E
+run failed its idempotence pass because a background Winget-AutoUpdate run (kicked off by the
+installer itself via `RUN_WAU=YES`) invalidated the per-user `winget.exe` alias for longer than
+the 15s launch-retry window from #253, and the pre-check then misreported the already-installed
+Windows Terminal as missing. `Install-WingetPackage` now gives launch failures their own
+doubling-backoff budget (default 75s) and re-resolves the executable through the registered
+`Microsoft.DesktopAppInstaller` package location (bypassing the alias) on every launch retry;
+`Test-WingetPackageInstalled` retries once through the same bypass.
 
 Healthy. **The 2026-07-08 whole-repo multi-agent code-review wave is fully resolved**: all 17
 issues it filed ([#176](https://github.com/J-MaFf/winget-app-setup/issues/176)–[#192](https://github.com/J-MaFf/winget-app-setup/issues/192))
@@ -173,6 +183,7 @@ Pester installs persist across runs there ([#161](https://github.com/J-MaFf/wing
 
 | Issue | Description | Status |
 |-------|-------------|--------|
+| [#258](https://github.com/J-MaFf/winget-app-setup/issues/258) | E2E install run failed: winget alias inaccessible through every launch retry (WAU/App Installer upgrade race) | In review |
 | [#225](https://github.com/J-MaFf/winget-app-setup/issues/225) | Bootstrap PowerShell 7 from Windows PowerShell 5.1 instead of failing fast | In review — PR [#228](https://github.com/J-MaFf/winget-app-setup/pull/228) |
 
 ## Natural Next Steps

--- a/WingetAppSetup/Private/WingetLaunchResilience.ps1
+++ b/WingetAppSetup/Private/WingetLaunchResilience.ps1
@@ -1,0 +1,84 @@
+# Winget launch resilience helpers (issue #258). Start-Process can fail to launch winget.exe at
+# all when the per-user app-execution alias under %LOCALAPPDATA%\Microsoft\WindowsApps is broken
+# or locked - most commonly because the Microsoft.DesktopAppInstaller MSIX package is being
+# upgraded or re-registered at that moment (e.g. by a background Winget-AutoUpdate run, which the
+# installer itself kicks off via RUN_WAU=YES). These helpers classify that failure and resolve a
+# concrete winget.exe path that bypasses the alias entirely, so retries can recover instead of
+# hammering the same broken reparse point.
+
+<#
+.SYNOPSIS
+    Returns true when a Start-Process exception message indicates a transient winget launch failure.
+.DESCRIPTION
+    Matches the two Win32 errors Start-Process surfaces as a terminating exception when winget.exe's
+    own file is transiently inaccessible (issues #253/#258): ERROR_CANT_ACCESS_FILE (1920, "The file
+    cannot be accessed by the system.") and the sibling ERROR_SHARING_VIOLATION ("...being used by
+    another process."). Matched case-insensitively; anything else (e.g. winget genuinely missing
+    from PATH) is a real failure the caller should not retry.
+.PARAMETER Message
+    The exception message to classify.
+.RETURNS
+    [bool]
+#>
+function Test-TransientWingetLaunchError {
+    param (
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Message
+    )
+
+    return $Message -match 'cannot be accessed by the system|being used by another process'
+}
+
+<#
+.SYNOPSIS
+    Resolves the winget executable to launch, optionally bypassing the app-execution alias.
+.DESCRIPTION
+    By default returns the bare command name 'winget', which Start-Process resolves through PATH to
+    the per-user app-execution alias - the fast path that works whenever winget is healthy.
+
+    With -BypassAlias, resolves the real winget.exe inside the registered
+    Microsoft.DesktopAppInstaller package's install location instead (the documented workaround for
+    contexts where the alias is unusable, e.g. SYSTEM). This matters during a DesktopAppInstaller
+    upgrade (issue #258): the alias reparse point can stay broken or locked for the whole
+    registration window, while Get-AppxPackage always reports the currently registered package - so
+    re-resolving on each retry converges on a launchable executable as soon as the new package
+    version lands. Falls back to 'winget' when the package (or its winget.exe) cannot be resolved,
+    preserving the prior behavior.
+.PARAMETER BypassAlias
+    Resolve the concrete winget.exe under the DesktopAppInstaller package install location instead
+    of relying on the PATH alias.
+.RETURNS
+    [string] An absolute path to winget.exe, or the bare command name 'winget'.
+#>
+function Resolve-WingetExecutable {
+    param (
+        [Parameter(Mandatory = $false)]
+        [switch]$BypassAlias
+    )
+
+    if (-not $BypassAlias) {
+        return 'winget'
+    }
+
+    try {
+        # Newest registered version first: mid-upgrade both old and new can briefly be visible, and
+        # the newest is the one whose files are guaranteed to exist once registration completes.
+        $package = Get-AppxPackage -Name 'Microsoft.DesktopAppInstaller' -ErrorAction Stop |
+            Sort-Object -Property { [version]$_.Version } -Descending |
+            Select-Object -First 1
+        if ($package -and $package.InstallLocation) {
+            $candidate = Join-Path $package.InstallLocation 'winget.exe'
+            if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+                return $candidate
+            }
+        }
+    }
+    catch {
+        # Get-AppxPackage can fail under PowerShell 7 when the Appx compatibility session is
+        # unavailable; the alias fallback below keeps the caller's retry loop functional.
+    }
+
+    return 'winget'
+}

--- a/WingetAppSetup/Public/WingetCore.ps1
+++ b/WingetAppSetup/Public/WingetCore.ps1
@@ -404,10 +404,14 @@ function Install-WingetPackage {
             $exitCode = $proc.ExitCode
         }
         catch {
-            if (-not (Test-TransientWingetLaunchError -Message $_.Exception.Message)) {
-                # Not a known-transient launch failure (e.g. winget genuinely missing) — preserve
-                # the prior behavior of letting it propagate instead of masking a real problem as
-                # an ordinary install failure.
+            if (-not (Test-TransientWingetLaunchError -Message $_.Exception.Message) -and $wingetExecutable -eq 'winget') {
+                # Not a known-transient launch failure of the alias (e.g. winget genuinely
+                # missing) — preserve the prior behavior of letting it propagate instead of
+                # masking a real problem as an ordinary install failure. A concrete bypass path
+                # is exempt from this re-throw: the package version it named can be deleted
+                # mid-backoff by the very App Installer upgrade being ridden out (surfacing as
+                # ERROR_FILE_NOT_FOUND, not the file-lock errors), and the right response is to
+                # re-resolve on the next launch retry, not to abort the install loop.
                 throw
             }
 

--- a/WingetAppSetup/Public/WingetCore.ps1
+++ b/WingetAppSetup/Public/WingetCore.ps1
@@ -293,9 +293,21 @@ function Initialize-WingetSourcesForUser {
     retry loop below entirely: on a GitHub-hosted E2E runner this was observed to fail every
     install in a run, surviving even the caller's separate one-shot retry pass, because neither
     layer paused before retrying (issue #253). The Start-Process call is now wrapped so this
-    specific class of launch exception is retried with the same backoff as the session error,
-    instead of propagating out of the function on the first attempt. Any other exception (e.g.
-    winget genuinely missing) is re-thrown unchanged so it is not silently swallowed.
+    specific class of launch exception is retried, instead of propagating out of the function on
+    the first attempt. Any other exception (e.g. winget genuinely missing) is re-thrown unchanged
+    so it is not silently swallowed.
+
+    Launch failures have their own retry budget, longer than the session-error one (issue #258):
+    the dominant real-world cause is a Microsoft.DesktopAppInstaller (App Installer) upgrade or
+    re-registration in flight - e.g. the background Winget-AutoUpdate run this installer itself
+    starts via RUN_WAU=YES - which breaks the per-user winget.exe app-execution alias for the
+    whole registration window, far longer than the 15s the #253 backoff covered (observed on run
+    30253761253: every launch failed across both install passes). Two things changed: each launch
+    retry first re-resolves the executable via Resolve-WingetExecutable -BypassAlias, launching
+    the registered package's own winget.exe directly instead of the broken alias; and the launch
+    backoff doubles across MaxLaunchAttempts (default 5: 5s+10s+20s+40s = 75s of coverage) so the
+    retry window outlasts a typical App Installer registration. A failed launch never ran winget,
+    so it does not consume one of the MaxAttempts install attempts.
 
     Installs prefer `--scope machine` (issue #159): user-scope installs land in the elevated
     account's profile rather than the logged-on user's, and packages that ship both MSIX and MSI
@@ -315,14 +327,21 @@ function Initialize-WingetSourcesForUser {
     Maximum number of install attempts while the session error keeps recurring. Default 3.
 .PARAMETER InitialDelaySeconds
     Seconds to wait before the first retry; the wait doubles on each subsequent retry. Default 5.
+.PARAMETER MaxLaunchAttempts
+    Maximum number of times to attempt launching winget.exe while Start-Process keeps throwing the
+    transient file-lock exception (issue #258). Separate from MaxAttempts because a failed launch
+    never ran an install; the wait starts at InitialDelaySeconds and doubles on each launch retry.
+    Default 5 (75s of total backoff at the default InitialDelaySeconds).
 .RETURNS
-    [hashtable] @{ ExitCode = <int|$null>; Attempts = <int>; SessionErrorExhausted = <bool>; MachineScopeFellBack = <bool>; LaunchErrorExhausted = <bool> }
+    [hashtable] @{ ExitCode = <int|$null>; Attempts = <int>; SessionErrorExhausted = <bool>; MachineScopeFellBack = <bool>; LaunchErrorExhausted = <bool>; LaunchAttempts = <int> }
     SessionErrorExhausted is True only when every attempt failed with the session error.
     MachineScopeFellBack is True when the package had no machine-scope installer and the install
     was retried at winget's default scope. Attempts counts install attempts at the finally
-    selected scope; the one-time scope fallback does not consume a session-error attempt.
-    LaunchErrorExhausted is True only when every attempt failed to launch winget.exe at all (issue
-    #253); ExitCode is $null in that case, since no process ever ran to report one.
+    selected scope; the one-time scope fallback does not consume a session-error attempt, and
+    neither does a failed launch (no process ran). LaunchAttempts counts failed winget launches.
+    LaunchErrorExhausted is True only when winget.exe could not be launched at all through every
+    launch attempt (issues #253/#258); ExitCode is $null and Attempts is 0 in that case, since no
+    process ever ran to report an exit code.
 #>
 function Install-WingetPackage {
     param (
@@ -336,7 +355,10 @@ function Install-WingetPackage {
         [int]$MaxAttempts = 3,
 
         [Parameter(Mandatory = $false)]
-        [int]$InitialDelaySeconds = 5
+        [int]$InitialDelaySeconds = 5,
+
+        [Parameter(Mandatory = $false)]
+        [int]$MaxLaunchAttempts = 5
     )
 
     # 0x80073D19 (ERROR_DEPLOYMENT_BLOCKED_BY_USER_LOG_OFF) as a signed Int32, which is how winget
@@ -345,12 +367,6 @@ function Install-WingetPackage {
     # 0x8A150010 (APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER) as a signed Int32: returned when
     # the --scope machine requirement filters out every installer in the package's manifest.
     $noApplicableInstallerExitCode = -1978335216
-    # Text fragments of the Win32 errors Start-Process surfaces as a terminating exception when it
-    # cannot even launch winget.exe (issue #253): ERROR_CANT_ACCESS_FILE (1920, "The file cannot be
-    # accessed by the system.") and the sibling ERROR_SHARING_VIOLATION ("...being used by another
-    # process."). Matched case-insensitively against the exception message; anything else is a real
-    # failure (e.g. winget missing from PATH) and is re-thrown rather than retried.
-    $transientLaunchErrorPattern = 'cannot be accessed by the system|being used by another process'
 
     $attempt = 0
     $delay = $InitialDelaySeconds
@@ -358,6 +374,9 @@ function Install-WingetPackage {
     $useMachineScope = $true
     $machineScopeFellBack = $false
     $launchErrorExhausted = $false
+    $launchAttempt = 0
+    $launchDelay = $InitialDelaySeconds
+    $wingetExecutable = Resolve-WingetExecutable
 
     while ($attempt -lt $MaxAttempts) {
         $attempt++
@@ -381,27 +400,36 @@ function Install-WingetPackage {
         }
 
         try {
-            $proc = Start-Process -FilePath 'winget' -ArgumentList $installArgs -NoNewWindow -Wait -PassThru
+            $proc = Start-Process -FilePath $wingetExecutable -ArgumentList $installArgs -NoNewWindow -Wait -PassThru
             $exitCode = $proc.ExitCode
-            $launchErrorExhausted = $false
         }
         catch {
-            if ($_.Exception.Message -notmatch $transientLaunchErrorPattern) {
+            if (-not (Test-TransientWingetLaunchError -Message $_.Exception.Message)) {
                 # Not a known-transient launch failure (e.g. winget genuinely missing) — preserve
                 # the prior behavior of letting it propagate instead of masking a real problem as
                 # an ordinary install failure.
                 throw
             }
 
-            $launchErrorExhausted = $true
-            if ($attempt -lt $MaxAttempts) {
-                Write-WarningMessage "Could not launch winget for $PackageId - its executable appears transiently locked ($($_.Exception.Message)). Waiting ${delay}s before retry $($attempt + 1) of ${MaxAttempts}..."
-                Start-Sleep -Seconds $delay
-                $delay = $delay * 2
+            # A failed launch never ran winget, so it must not consume an install attempt; launch
+            # failures have their own budget (issue #258).
+            $attempt--
+            $launchAttempt++
+            if ($launchAttempt -lt $MaxLaunchAttempts) {
+                # The usual cause is the winget.exe app-execution alias breaking while the
+                # DesktopAppInstaller package is upgraded/re-registered underneath us (e.g. by a
+                # background Winget-AutoUpdate run). Re-resolve fresh each retry, preferring the
+                # registered package's own winget.exe over the alias: as soon as the new package
+                # version lands, this converges on a launchable executable.
+                $wingetExecutable = Resolve-WingetExecutable -BypassAlias
+                Write-WarningMessage "Could not launch winget for $PackageId - its executable appears transiently locked ($($_.Exception.Message)). Waiting ${launchDelay}s before launch retry $($launchAttempt + 1) of ${MaxLaunchAttempts} (next attempt uses '$wingetExecutable')..."
+                Start-Sleep -Seconds $launchDelay
+                $launchDelay = $launchDelay * 2
                 continue
             }
 
-            Write-WarningMessage "Still unable to launch winget for $PackageId after ${MaxAttempts} attempts (executable transiently inaccessible on every attempt)."
+            Write-WarningMessage "Still unable to launch winget for $PackageId after ${MaxLaunchAttempts} launch attempts (executable inaccessible through every attempt, including via the DesktopAppInstaller package location)."
+            $launchErrorExhausted = $true
             $exitCode = $null
             break
         }
@@ -440,6 +468,7 @@ function Install-WingetPackage {
         SessionErrorExhausted = ($exitCode -eq $sessionLogoffExitCode)
         MachineScopeFellBack  = $machineScopeFellBack
         LaunchErrorExhausted  = $launchErrorExhausted
+        LaunchAttempts        = $launchAttempt
     }
 }
 
@@ -461,6 +490,13 @@ function Install-WingetPackage {
     Both modes determine "installed" via Test-WingetListOutputContainsPackageId rather than a plain
     substring .Contains check, so an unrelated listed id that merely contains $PackageId as a
     substring (e.g. target 'Foo.Bar' inside listed id 'Foo.BarBaz') cannot false-positive.
+
+    In timeout mode, a Start-Process launch failure of the transient file-lock class (the winget
+    app-execution alias breaking during a DesktopAppInstaller upgrade, issue #258) is retried once
+    via Resolve-WingetExecutable -BypassAlias — launching the registered package's own winget.exe
+    directly — before the check gives up. Without this, the outage made this check silently report
+    an actually-installed package as missing, which is how run 30253761253 marked the already
+    installed Microsoft.WindowsTerminal as a failed install.
 .PARAMETER PackageId
     The winget package id to check.
 .PARAMETER TimeoutSeconds
@@ -489,12 +525,32 @@ function Test-WingetPackageInstalled {
         $stderrFile = Join-Path $env:TEMP "winget_list_error_$tempSuffix.txt"
 
         try {
-            $listProcess = Start-Process -FilePath 'winget' `
-                -ArgumentList 'list', '--exact', '--id', $PackageId, '--accept-source-agreements', '--disable-interactivity' `
-                -NoNewWindow `
-                -PassThru `
-                -RedirectStandardOutput $stdoutFile `
-                -RedirectStandardError $stderrFile
+            $listArgs = @('list', '--exact', '--id', $PackageId, '--accept-source-agreements', '--disable-interactivity')
+            try {
+                $listProcess = Start-Process -FilePath 'winget' `
+                    -ArgumentList $listArgs `
+                    -NoNewWindow `
+                    -PassThru `
+                    -RedirectStandardOutput $stdoutFile `
+                    -RedirectStandardError $stderrFile
+            }
+            catch {
+                if (-not (Test-TransientWingetLaunchError -Message $_.Exception.Message)) {
+                    throw
+                }
+                # The winget alias is transiently inaccessible (issue #258) — retry once through
+                # the DesktopAppInstaller package's own winget.exe so an installed package is not
+                # misreported as missing. A failure here falls through to the outer catch, which
+                # keeps the original no-throw contract.
+                $bypassExecutable = Resolve-WingetExecutable -BypassAlias
+                Write-WarningMessage "Could not launch winget to check $PackageId ($($_.Exception.Message)). Retrying once via '$bypassExecutable'..."
+                $listProcess = Start-Process -FilePath $bypassExecutable `
+                    -ArgumentList $listArgs `
+                    -NoNewWindow `
+                    -PassThru `
+                    -RedirectStandardOutput $stdoutFile `
+                    -RedirectStandardError $stderrFile
+            }
 
             if (-not $listProcess.WaitForExit($TimeoutSeconds * 1000)) {
                 try { $listProcess.Kill() } catch { }

--- a/tests/WingetCore.Tests.ps1
+++ b/tests/WingetCore.Tests.ps1
@@ -606,10 +606,36 @@ Describe 'Install-WingetPackage (transient launch-exception backoff, issue #253)
         $result = Install-WingetPackage -PackageId 'Klocman.BulkCrapUninstaller' -MaxAttempts 3 -InitialDelaySeconds 1
 
         $result.ExitCode | Should -Be 0
-        $result.Attempts | Should -Be 2
+        # A failed launch never ran winget, so it does not consume an install attempt (issue #258).
+        $result.Attempts | Should -Be 1
+        $result.LaunchAttempts | Should -Be 1
         $result.LaunchErrorExhausted | Should -Be $false
         Should -Invoke Start-Process -Times 2 -Exactly
         Should -Invoke Start-Sleep -Times 1 -Exactly
+    }
+
+    It 'Re-resolves the executable past the broken alias on each launch retry (issue #258)' {
+        $script:packageWinget = 'C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_1.26.0.0_x64__8wekyb3d8bbwe\winget.exe'
+        Mock Resolve-WingetExecutable {
+            if ($BypassAlias) { $script:packageWinget } else { 'winget' }
+        }
+        Mock Start-Process {
+            if ($FilePath -eq 'winget') {
+                # The app-execution alias stays broken for the whole test: only the concrete
+                # package-location winget.exe can launch.
+                throw 'This command cannot be run due to the error: The file cannot be accessed by the system.'
+            }
+            [pscustomobject]@{ ExitCode = 0 }
+        }
+
+        $result = Install-WingetPackage -PackageId 'Microsoft.WindowsTerminal' -MaxAttempts 3 -InitialDelaySeconds 1
+
+        $result.ExitCode | Should -Be 0
+        $result.Attempts | Should -Be 1
+        $result.LaunchAttempts | Should -Be 1
+        $result.LaunchErrorExhausted | Should -Be $false
+        Should -Invoke Resolve-WingetExecutable -Times 1 -Exactly -ParameterFilter { [bool]$BypassAlias }
+        Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter { $FilePath -eq $packageWinget }
     }
 
     It 'Also retries the sibling sharing-violation launch exception' {
@@ -629,19 +655,37 @@ Describe 'Install-WingetPackage (transient launch-exception backoff, issue #253)
         Should -Invoke Start-Process -Times 2 -Exactly
     }
 
-    It 'Exhausts MaxAttempts when winget.exe stays transiently inaccessible, returning a null ExitCode' {
+    It 'Exhausts MaxLaunchAttempts when winget.exe stays transiently inaccessible, returning a null ExitCode' {
         Mock Start-Process {
             throw 'This command cannot be run due to the error: The file cannot be accessed by the system.'
         }
 
-        $result = Install-WingetPackage -PackageId 'Microsoft.PowerShell' -MaxAttempts 3 -InitialDelaySeconds 1
+        $result = Install-WingetPackage -PackageId 'Microsoft.PowerShell' -MaxAttempts 3 -InitialDelaySeconds 1 -MaxLaunchAttempts 3
 
         $result.ExitCode | Should -Be $null
-        $result.Attempts | Should -Be 3
+        # No install ever ran: failed launches have their own budget and counter (issue #258).
+        $result.Attempts | Should -Be 0
+        $result.LaunchAttempts | Should -Be 3
         $result.LaunchErrorExhausted | Should -Be $true
         Should -Invoke Start-Process -Times 3 -Exactly
-        # Sleeps between attempts only (1->2 and 2->3), never after the final attempt.
+        # Sleeps between launch attempts only (1->2 and 2->3), never after the final attempt.
         Should -Invoke Start-Sleep -Times 2 -Exactly
+    }
+
+    It 'Gives launch failures a larger default budget than install attempts (75s window, issue #258)' {
+        Mock Start-Process {
+            throw 'This command cannot be run due to the error: The file cannot be accessed by the system.'
+        }
+        $script:launchWaits = @()
+        Mock Start-Sleep { $script:launchWaits += $Seconds }
+
+        $result = Install-WingetPackage -PackageId 'Microsoft.WindowsTerminal' -MaxAttempts 3 -InitialDelaySeconds 5
+
+        $result.LaunchErrorExhausted | Should -Be $true
+        $result.LaunchAttempts | Should -Be 5
+        Should -Invoke Start-Process -Times 5 -Exactly
+        # Doubling backoff sized to outlast an App Installer re-registration window.
+        $script:launchWaits | Should -Be @(5, 10, 20, 40)
     }
 
     It 'Re-throws an unrelated Start-Process exception instead of retrying it' {
@@ -777,6 +821,45 @@ Describe 'Test-WingetPackageInstalled (timeout support, issue #188)' {
             $result.Installed | Should -Be $false
             $result.TimedOut | Should -Be $false
             $result.ExitCode | Should -Be $null
+        }
+
+        It 'Retries once past a broken winget alias via the package location so an installed app is not misreported (issue #258)' {
+            Mock Write-WarningMessage { }
+            $script:packageWinget = 'C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_1.26.0.0_x64__8wekyb3d8bbwe\winget.exe'
+            Mock Resolve-WingetExecutable { $script:packageWinget }
+            Mock Start-Process {
+                if ($FilePath -eq 'winget') {
+                    throw 'This command cannot be run due to the error: The file cannot be accessed by the system.'
+                }
+                $p = [pscustomobject]@{ ExitCode = 0 }
+                $p | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value { param($ms) $true }
+                $p | Add-Member -MemberType ScriptMethod -Name Kill -Value { }
+                $p
+            }
+            Mock Get-Content { 'Microsoft.WindowsTerminal  1.22.0  winget' }
+
+            $result = Test-WingetPackageInstalled -PackageId 'Microsoft.WindowsTerminal' -TimeoutSeconds 15
+
+            $result.Installed | Should -Be $true
+            $result.TimedOut | Should -Be $false
+            $result.ExitCode | Should -Be 0
+            Should -Invoke Resolve-WingetExecutable -Times 1 -Exactly -ParameterFilter { [bool]$BypassAlias }
+            Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter { $FilePath -eq $script:packageWinget }
+        }
+
+        It 'Still reports a no-throw failure when both the alias and the package-location launch fail (issue #258)' {
+            Mock Write-WarningMessage { }
+            Mock Resolve-WingetExecutable { 'C:\pf\winget.exe' }
+            Mock Start-Process {
+                throw 'This command cannot be run due to the error: The file cannot be accessed by the system.'
+            }
+
+            $result = Test-WingetPackageInstalled -PackageId 'Test.App' -TimeoutSeconds 15
+
+            $result.Installed | Should -Be $false
+            $result.TimedOut | Should -Be $false
+            $result.ExitCode | Should -Be $null
+            Should -Invoke Start-Process -Times 2 -Exactly
         }
 
         It 'Uses unique temp file names on every run and cleans them up (issue #177)' {

--- a/tests/WingetCore.Tests.ps1
+++ b/tests/WingetCore.Tests.ps1
@@ -698,6 +698,36 @@ Describe 'Install-WingetPackage (transient launch-exception backoff, issue #253)
         Should -Invoke Start-Process -Times 1 -Exactly
         Should -Invoke Start-Sleep -Times 0 -Exactly
     }
+
+    It 'Keeps retrying when the resolved bypass path itself vanishes mid-backoff (issue #258)' {
+        # Attempt 1: the alias is locked. Attempt 2: the resolved package path was deleted by the
+        # completing App Installer upgrade (ERROR_FILE_NOT_FOUND - NOT a file-lock error). That
+        # must re-enter the launch retry with a fresh resolution, not abort the install loop.
+        # Attempt 3: the freshly re-resolved path works.
+        $script:resolveCount = 0
+        Mock Resolve-WingetExecutable {
+            if (-not $BypassAlias) { return 'winget' }
+            $script:resolveCount++
+            "C:\WindowsApps\DAI_v$script:resolveCount\winget.exe"
+        }
+        Mock Start-Process {
+            if ($FilePath -eq 'winget') {
+                throw 'This command cannot be run due to the error: The file cannot be accessed by the system.'
+            }
+            if ($FilePath -eq 'C:\WindowsApps\DAI_v1\winget.exe') {
+                throw 'This command cannot be run due to the error: The system cannot find the file specified.'
+            }
+            [pscustomobject]@{ ExitCode = 0 }
+        }
+
+        $result = Install-WingetPackage -PackageId 'Microsoft.WindowsTerminal' -MaxAttempts 3 -InitialDelaySeconds 1
+
+        $result.ExitCode | Should -Be 0
+        $result.Attempts | Should -Be 1
+        $result.LaunchAttempts | Should -Be 2
+        $result.LaunchErrorExhausted | Should -Be $false
+        Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter { $FilePath -eq 'C:\WindowsApps\DAI_v2\winget.exe' }
+    }
 }
 
 Describe 'Test-WingetPackageInstalled (timeout support, issue #188)' {

--- a/tests/WingetLaunchResilience.Tests.ps1
+++ b/tests/WingetLaunchResilience.Tests.ps1
@@ -1,0 +1,87 @@
+# Tests for WingetAppSetup/Private/WingetLaunchResilience.ps1 (issue #258): classification of
+# transient Start-Process winget-launch failures, and resolution of a concrete winget.exe that
+# bypasses the per-user app-execution alias while DesktopAppInstaller is mid-upgrade.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot 'TestHelpers.ps1')
+}
+
+Describe 'Test-TransientWingetLaunchError' {
+    It 'Classifies ERROR_CANT_ACCESS_FILE as transient' {
+        Test-TransientWingetLaunchError -Message 'This command cannot be run due to the error: The file cannot be accessed by the system.' |
+            Should -Be $true
+    }
+
+    It 'Classifies ERROR_SHARING_VIOLATION as transient' {
+        Test-TransientWingetLaunchError -Message 'The process cannot access the file because it is being used by another process.' |
+            Should -Be $true
+    }
+
+    It 'Matches case-insensitively' {
+        Test-TransientWingetLaunchError -Message 'THE FILE CANNOT BE ACCESSED BY THE SYSTEM.' |
+            Should -Be $true
+    }
+
+    It 'Does not classify an unrelated launch failure as transient' {
+        Test-TransientWingetLaunchError -Message 'The system cannot find the file specified.' |
+            Should -Be $false
+    }
+
+    It 'Handles a null or empty message without throwing' {
+        Test-TransientWingetLaunchError -Message $null | Should -Be $false
+        Test-TransientWingetLaunchError -Message '' | Should -Be $false
+    }
+}
+
+Describe 'Resolve-WingetExecutable' {
+    It 'Returns the bare command name without -BypassAlias, and never queries the package database' {
+        Mock Get-AppxPackage { throw 'must not be called on the fast path' }
+
+        Resolve-WingetExecutable | Should -Be 'winget'
+
+        Should -Invoke Get-AppxPackage -Times 0 -Exactly
+    }
+
+    Context 'With -BypassAlias' {
+        It 'Returns winget.exe under the registered DesktopAppInstaller package install location' {
+            $script:installLocation = 'C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_1.26.0.0_x64__8wekyb3d8bbwe'
+            Mock Get-AppxPackage { [pscustomobject]@{ Version = '1.26.0.0'; InstallLocation = $script:installLocation } }
+            Mock Test-Path { $true }
+
+            Resolve-WingetExecutable -BypassAlias | Should -Be (Join-Path $script:installLocation 'winget.exe')
+
+            Should -Invoke Get-AppxPackage -Times 1 -Exactly -ParameterFilter { $Name -eq 'Microsoft.DesktopAppInstaller' }
+        }
+
+        It 'Prefers the newest registered version when several are visible mid-upgrade' {
+            Mock Get-AppxPackage {
+                @(
+                    [pscustomobject]@{ Version = '1.9.25200.0'; InstallLocation = 'C:\WindowsApps\DAI_old' }
+                    [pscustomobject]@{ Version = '1.26.0.0'; InstallLocation = 'C:\WindowsApps\DAI_new' }
+                )
+            }
+            Mock Test-Path { $true }
+
+            Resolve-WingetExecutable -BypassAlias | Should -Be (Join-Path 'C:\WindowsApps\DAI_new' 'winget.exe')
+        }
+
+        It 'Falls back to the alias when the package has no winget.exe on disk' {
+            Mock Get-AppxPackage { [pscustomobject]@{ Version = '1.26.0.0'; InstallLocation = 'C:\WindowsApps\DAI' } }
+            Mock Test-Path { $false }
+
+            Resolve-WingetExecutable -BypassAlias | Should -Be 'winget'
+        }
+
+        It 'Falls back to the alias when the package is not registered' {
+            Mock Get-AppxPackage { $null }
+
+            Resolve-WingetExecutable -BypassAlias | Should -Be 'winget'
+        }
+
+        It 'Falls back to the alias when Get-AppxPackage throws (e.g. no Appx compatibility session)' {
+            Mock Get-AppxPackage { throw 'Operation is not supported on this platform.' }
+
+            Resolve-WingetExecutable -BypassAlias | Should -Be 'winget'
+        }
+    }
+}

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -58,12 +58,12 @@ param (
 # This script is assembled from the WingetAppSetup module by build/Build-WingetInstallScript.ps1.
 # Edit the function source under WingetAppSetup/Public and WingetAppSetup/Private, then re-run the
 # build to regenerate this file. See readme.md ("Project layout") for details.
-# Build id: 1.0.0+b25dab43 (module version + SHA256 fragment of the function content; issue #189).
+# Build id: 1.0.0+5edd59af (module version + SHA256 fragment of the function content; issue #189).
 # ------------------------------------------------------------------------------------------------
 
 # Content-derived build identity, logged at startup so a transcript from a remote machine
 # identifies exactly which installer build produced it (issue #189).
-$script:InstallerBuildId = '1.0.0+b25dab43'
+$script:InstallerBuildId = '1.0.0+5edd59af'
 
 # ------------------------------------------------Functions------------------------------------------------
 
@@ -1451,6 +1451,92 @@ function Test-WingetSourceHealth {
         Functional = $sourceIsFunctional
         Healthy    = ($sourceIsListed -and $sourceIsFunctional)
     }
+}
+
+# --- WingetLaunchResilience ---
+# Winget launch resilience helpers (issue #258). Start-Process can fail to launch winget.exe at
+# all when the per-user app-execution alias under %LOCALAPPDATA%\Microsoft\WindowsApps is broken
+# or locked - most commonly because the Microsoft.DesktopAppInstaller MSIX package is being
+# upgraded or re-registered at that moment (e.g. by a background Winget-AutoUpdate run, which the
+# installer itself kicks off via RUN_WAU=YES). These helpers classify that failure and resolve a
+# concrete winget.exe path that bypasses the alias entirely, so retries can recover instead of
+# hammering the same broken reparse point.
+
+<#
+.SYNOPSIS
+    Returns true when a Start-Process exception message indicates a transient winget launch failure.
+.DESCRIPTION
+    Matches the two Win32 errors Start-Process surfaces as a terminating exception when winget.exe's
+    own file is transiently inaccessible (issues #253/#258): ERROR_CANT_ACCESS_FILE (1920, "The file
+    cannot be accessed by the system.") and the sibling ERROR_SHARING_VIOLATION ("...being used by
+    another process."). Matched case-insensitively; anything else (e.g. winget genuinely missing
+    from PATH) is a real failure the caller should not retry.
+.PARAMETER Message
+    The exception message to classify.
+.RETURNS
+    [bool]
+#>
+function Test-TransientWingetLaunchError {
+    param (
+        [Parameter(Mandatory = $false)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$Message
+    )
+
+    return $Message -match 'cannot be accessed by the system|being used by another process'
+}
+
+<#
+.SYNOPSIS
+    Resolves the winget executable to launch, optionally bypassing the app-execution alias.
+.DESCRIPTION
+    By default returns the bare command name 'winget', which Start-Process resolves through PATH to
+    the per-user app-execution alias - the fast path that works whenever winget is healthy.
+
+    With -BypassAlias, resolves the real winget.exe inside the registered
+    Microsoft.DesktopAppInstaller package's install location instead (the documented workaround for
+    contexts where the alias is unusable, e.g. SYSTEM). This matters during a DesktopAppInstaller
+    upgrade (issue #258): the alias reparse point can stay broken or locked for the whole
+    registration window, while Get-AppxPackage always reports the currently registered package - so
+    re-resolving on each retry converges on a launchable executable as soon as the new package
+    version lands. Falls back to 'winget' when the package (or its winget.exe) cannot be resolved,
+    preserving the prior behavior.
+.PARAMETER BypassAlias
+    Resolve the concrete winget.exe under the DesktopAppInstaller package install location instead
+    of relying on the PATH alias.
+.RETURNS
+    [string] An absolute path to winget.exe, or the bare command name 'winget'.
+#>
+function Resolve-WingetExecutable {
+    param (
+        [Parameter(Mandatory = $false)]
+        [switch]$BypassAlias
+    )
+
+    if (-not $BypassAlias) {
+        return 'winget'
+    }
+
+    try {
+        # Newest registered version first: mid-upgrade both old and new can briefly be visible, and
+        # the newest is the one whose files are guaranteed to exist once registration completes.
+        $package = Get-AppxPackage -Name 'Microsoft.DesktopAppInstaller' -ErrorAction Stop |
+            Sort-Object -Property { [version]$_.Version } -Descending |
+            Select-Object -First 1
+        if ($package -and $package.InstallLocation) {
+            $candidate = Join-Path $package.InstallLocation 'winget.exe'
+            if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+                return $candidate
+            }
+        }
+    }
+    catch {
+        # Get-AppxPackage can fail under PowerShell 7 when the Appx compatibility session is
+        # unavailable; the alias fallback below keeps the caller's retry loop functional.
+    }
+
+    return 'winget'
 }
 
 # --- AppCatalog ---
@@ -3187,9 +3273,21 @@ function Initialize-WingetSourcesForUser {
     retry loop below entirely: on a GitHub-hosted E2E runner this was observed to fail every
     install in a run, surviving even the caller's separate one-shot retry pass, because neither
     layer paused before retrying (issue #253). The Start-Process call is now wrapped so this
-    specific class of launch exception is retried with the same backoff as the session error,
-    instead of propagating out of the function on the first attempt. Any other exception (e.g.
-    winget genuinely missing) is re-thrown unchanged so it is not silently swallowed.
+    specific class of launch exception is retried, instead of propagating out of the function on
+    the first attempt. Any other exception (e.g. winget genuinely missing) is re-thrown unchanged
+    so it is not silently swallowed.
+
+    Launch failures have their own retry budget, longer than the session-error one (issue #258):
+    the dominant real-world cause is a Microsoft.DesktopAppInstaller (App Installer) upgrade or
+    re-registration in flight - e.g. the background Winget-AutoUpdate run this installer itself
+    starts via RUN_WAU=YES - which breaks the per-user winget.exe app-execution alias for the
+    whole registration window, far longer than the 15s the #253 backoff covered (observed on run
+    30253761253: every launch failed across both install passes). Two things changed: each launch
+    retry first re-resolves the executable via Resolve-WingetExecutable -BypassAlias, launching
+    the registered package's own winget.exe directly instead of the broken alias; and the launch
+    backoff doubles across MaxLaunchAttempts (default 5: 5s+10s+20s+40s = 75s of coverage) so the
+    retry window outlasts a typical App Installer registration. A failed launch never ran winget,
+    so it does not consume one of the MaxAttempts install attempts.
 
     Installs prefer `--scope machine` (issue #159): user-scope installs land in the elevated
     account's profile rather than the logged-on user's, and packages that ship both MSIX and MSI
@@ -3209,14 +3307,21 @@ function Initialize-WingetSourcesForUser {
     Maximum number of install attempts while the session error keeps recurring. Default 3.
 .PARAMETER InitialDelaySeconds
     Seconds to wait before the first retry; the wait doubles on each subsequent retry. Default 5.
+.PARAMETER MaxLaunchAttempts
+    Maximum number of times to attempt launching winget.exe while Start-Process keeps throwing the
+    transient file-lock exception (issue #258). Separate from MaxAttempts because a failed launch
+    never ran an install; the wait starts at InitialDelaySeconds and doubles on each launch retry.
+    Default 5 (75s of total backoff at the default InitialDelaySeconds).
 .RETURNS
-    [hashtable] @{ ExitCode = <int|$null>; Attempts = <int>; SessionErrorExhausted = <bool>; MachineScopeFellBack = <bool>; LaunchErrorExhausted = <bool> }
+    [hashtable] @{ ExitCode = <int|$null>; Attempts = <int>; SessionErrorExhausted = <bool>; MachineScopeFellBack = <bool>; LaunchErrorExhausted = <bool>; LaunchAttempts = <int> }
     SessionErrorExhausted is True only when every attempt failed with the session error.
     MachineScopeFellBack is True when the package had no machine-scope installer and the install
     was retried at winget's default scope. Attempts counts install attempts at the finally
-    selected scope; the one-time scope fallback does not consume a session-error attempt.
-    LaunchErrorExhausted is True only when every attempt failed to launch winget.exe at all (issue
-    #253); ExitCode is $null in that case, since no process ever ran to report one.
+    selected scope; the one-time scope fallback does not consume a session-error attempt, and
+    neither does a failed launch (no process ran). LaunchAttempts counts failed winget launches.
+    LaunchErrorExhausted is True only when winget.exe could not be launched at all through every
+    launch attempt (issues #253/#258); ExitCode is $null and Attempts is 0 in that case, since no
+    process ever ran to report an exit code.
 #>
 function Install-WingetPackage {
     param (
@@ -3230,7 +3335,10 @@ function Install-WingetPackage {
         [int]$MaxAttempts = 3,
 
         [Parameter(Mandatory = $false)]
-        [int]$InitialDelaySeconds = 5
+        [int]$InitialDelaySeconds = 5,
+
+        [Parameter(Mandatory = $false)]
+        [int]$MaxLaunchAttempts = 5
     )
 
     # 0x80073D19 (ERROR_DEPLOYMENT_BLOCKED_BY_USER_LOG_OFF) as a signed Int32, which is how winget
@@ -3239,12 +3347,6 @@ function Install-WingetPackage {
     # 0x8A150010 (APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER) as a signed Int32: returned when
     # the --scope machine requirement filters out every installer in the package's manifest.
     $noApplicableInstallerExitCode = -1978335216
-    # Text fragments of the Win32 errors Start-Process surfaces as a terminating exception when it
-    # cannot even launch winget.exe (issue #253): ERROR_CANT_ACCESS_FILE (1920, "The file cannot be
-    # accessed by the system.") and the sibling ERROR_SHARING_VIOLATION ("...being used by another
-    # process."). Matched case-insensitively against the exception message; anything else is a real
-    # failure (e.g. winget missing from PATH) and is re-thrown rather than retried.
-    $transientLaunchErrorPattern = 'cannot be accessed by the system|being used by another process'
 
     $attempt = 0
     $delay = $InitialDelaySeconds
@@ -3252,6 +3354,9 @@ function Install-WingetPackage {
     $useMachineScope = $true
     $machineScopeFellBack = $false
     $launchErrorExhausted = $false
+    $launchAttempt = 0
+    $launchDelay = $InitialDelaySeconds
+    $wingetExecutable = Resolve-WingetExecutable
 
     while ($attempt -lt $MaxAttempts) {
         $attempt++
@@ -3275,27 +3380,36 @@ function Install-WingetPackage {
         }
 
         try {
-            $proc = Start-Process -FilePath 'winget' -ArgumentList $installArgs -NoNewWindow -Wait -PassThru
+            $proc = Start-Process -FilePath $wingetExecutable -ArgumentList $installArgs -NoNewWindow -Wait -PassThru
             $exitCode = $proc.ExitCode
-            $launchErrorExhausted = $false
         }
         catch {
-            if ($_.Exception.Message -notmatch $transientLaunchErrorPattern) {
+            if (-not (Test-TransientWingetLaunchError -Message $_.Exception.Message)) {
                 # Not a known-transient launch failure (e.g. winget genuinely missing) — preserve
                 # the prior behavior of letting it propagate instead of masking a real problem as
                 # an ordinary install failure.
                 throw
             }
 
-            $launchErrorExhausted = $true
-            if ($attempt -lt $MaxAttempts) {
-                Write-WarningMessage "Could not launch winget for $PackageId - its executable appears transiently locked ($($_.Exception.Message)). Waiting ${delay}s before retry $($attempt + 1) of ${MaxAttempts}..."
-                Start-Sleep -Seconds $delay
-                $delay = $delay * 2
+            # A failed launch never ran winget, so it must not consume an install attempt; launch
+            # failures have their own budget (issue #258).
+            $attempt--
+            $launchAttempt++
+            if ($launchAttempt -lt $MaxLaunchAttempts) {
+                # The usual cause is the winget.exe app-execution alias breaking while the
+                # DesktopAppInstaller package is upgraded/re-registered underneath us (e.g. by a
+                # background Winget-AutoUpdate run). Re-resolve fresh each retry, preferring the
+                # registered package's own winget.exe over the alias: as soon as the new package
+                # version lands, this converges on a launchable executable.
+                $wingetExecutable = Resolve-WingetExecutable -BypassAlias
+                Write-WarningMessage "Could not launch winget for $PackageId - its executable appears transiently locked ($($_.Exception.Message)). Waiting ${launchDelay}s before launch retry $($launchAttempt + 1) of ${MaxLaunchAttempts} (next attempt uses '$wingetExecutable')..."
+                Start-Sleep -Seconds $launchDelay
+                $launchDelay = $launchDelay * 2
                 continue
             }
 
-            Write-WarningMessage "Still unable to launch winget for $PackageId after ${MaxAttempts} attempts (executable transiently inaccessible on every attempt)."
+            Write-WarningMessage "Still unable to launch winget for $PackageId after ${MaxLaunchAttempts} launch attempts (executable inaccessible through every attempt, including via the DesktopAppInstaller package location)."
+            $launchErrorExhausted = $true
             $exitCode = $null
             break
         }
@@ -3334,6 +3448,7 @@ function Install-WingetPackage {
         SessionErrorExhausted = ($exitCode -eq $sessionLogoffExitCode)
         MachineScopeFellBack  = $machineScopeFellBack
         LaunchErrorExhausted  = $launchErrorExhausted
+        LaunchAttempts        = $launchAttempt
     }
 }
 
@@ -3355,6 +3470,13 @@ function Install-WingetPackage {
     Both modes determine "installed" via Test-WingetListOutputContainsPackageId rather than a plain
     substring .Contains check, so an unrelated listed id that merely contains $PackageId as a
     substring (e.g. target 'Foo.Bar' inside listed id 'Foo.BarBaz') cannot false-positive.
+
+    In timeout mode, a Start-Process launch failure of the transient file-lock class (the winget
+    app-execution alias breaking during a DesktopAppInstaller upgrade, issue #258) is retried once
+    via Resolve-WingetExecutable -BypassAlias — launching the registered package's own winget.exe
+    directly — before the check gives up. Without this, the outage made this check silently report
+    an actually-installed package as missing, which is how run 30253761253 marked the already
+    installed Microsoft.WindowsTerminal as a failed install.
 .PARAMETER PackageId
     The winget package id to check.
 .PARAMETER TimeoutSeconds
@@ -3383,12 +3505,32 @@ function Test-WingetPackageInstalled {
         $stderrFile = Join-Path $env:TEMP "winget_list_error_$tempSuffix.txt"
 
         try {
-            $listProcess = Start-Process -FilePath 'winget' `
-                -ArgumentList 'list', '--exact', '--id', $PackageId, '--accept-source-agreements', '--disable-interactivity' `
-                -NoNewWindow `
-                -PassThru `
-                -RedirectStandardOutput $stdoutFile `
-                -RedirectStandardError $stderrFile
+            $listArgs = @('list', '--exact', '--id', $PackageId, '--accept-source-agreements', '--disable-interactivity')
+            try {
+                $listProcess = Start-Process -FilePath 'winget' `
+                    -ArgumentList $listArgs `
+                    -NoNewWindow `
+                    -PassThru `
+                    -RedirectStandardOutput $stdoutFile `
+                    -RedirectStandardError $stderrFile
+            }
+            catch {
+                if (-not (Test-TransientWingetLaunchError -Message $_.Exception.Message)) {
+                    throw
+                }
+                # The winget alias is transiently inaccessible (issue #258) — retry once through
+                # the DesktopAppInstaller package's own winget.exe so an installed package is not
+                # misreported as missing. A failure here falls through to the outer catch, which
+                # keeps the original no-throw contract.
+                $bypassExecutable = Resolve-WingetExecutable -BypassAlias
+                Write-WarningMessage "Could not launch winget to check $PackageId ($($_.Exception.Message)). Retrying once via '$bypassExecutable'..."
+                $listProcess = Start-Process -FilePath $bypassExecutable `
+                    -ArgumentList $listArgs `
+                    -NoNewWindow `
+                    -PassThru `
+                    -RedirectStandardOutput $stdoutFile `
+                    -RedirectStandardError $stderrFile
+            }
 
             if (-not $listProcess.WaitForExit($TimeoutSeconds * 1000)) {
                 try { $listProcess.Kill() } catch { }

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -58,12 +58,12 @@ param (
 # This script is assembled from the WingetAppSetup module by build/Build-WingetInstallScript.ps1.
 # Edit the function source under WingetAppSetup/Public and WingetAppSetup/Private, then re-run the
 # build to regenerate this file. See readme.md ("Project layout") for details.
-# Build id: 1.0.0+5edd59af (module version + SHA256 fragment of the function content; issue #189).
+# Build id: 1.0.0+40fcd2ea (module version + SHA256 fragment of the function content; issue #189).
 # ------------------------------------------------------------------------------------------------
 
 # Content-derived build identity, logged at startup so a transcript from a remote machine
 # identifies exactly which installer build produced it (issue #189).
-$script:InstallerBuildId = '1.0.0+5edd59af'
+$script:InstallerBuildId = '1.0.0+40fcd2ea'
 
 # ------------------------------------------------Functions------------------------------------------------
 
@@ -3384,10 +3384,14 @@ function Install-WingetPackage {
             $exitCode = $proc.ExitCode
         }
         catch {
-            if (-not (Test-TransientWingetLaunchError -Message $_.Exception.Message)) {
-                # Not a known-transient launch failure (e.g. winget genuinely missing) — preserve
-                # the prior behavior of letting it propagate instead of masking a real problem as
-                # an ordinary install failure.
+            if (-not (Test-TransientWingetLaunchError -Message $_.Exception.Message) -and $wingetExecutable -eq 'winget') {
+                # Not a known-transient launch failure of the alias (e.g. winget genuinely
+                # missing) — preserve the prior behavior of letting it propagate instead of
+                # masking a real problem as an ordinary install failure. A concrete bypass path
+                # is exempt from this re-throw: the package version it named can be deleted
+                # mid-backoff by the very App Installer upgrade being ridden out (surfacing as
+                # ERROR_FILE_NOT_FOUND, not the file-lock errors), and the right response is to
+                # re-resolve on the next launch retry, not to abort the install loop.
                 throw
             }
 


### PR DESCRIPTION
Fixes #258

## Root cause

The failed idempotence pass of E2E run [30253761253](https://github.com/J-MaFf/winget-app-setup/actions/runs/30253761253) was a **winget app-execution-alias outage caused by the installer itself**:

1. Pass 1 ends by installing Winget-AutoUpdate with `RUN_WAU=YES` (09:28:04), which immediately starts a background WAU run as SYSTEM — and WAU can upgrade App Installer (`Microsoft.DesktopAppInstaller`, i.e. winget itself) as part of that run.
2. Pass 2 starts at 09:28:06 and checks 9 apps fine, but ~20s in the DesktopAppInstaller upgrade/re-registration breaks the per-user `winget.exe` app-execution alias: from that moment **every** `Start-Process 'winget'` throws `ERROR_CANT_ACCESS_FILE` ("The file cannot be accessed by the system").
3. `Microsoft.WindowsTerminal` was simply the app whose pre-check landed inside the outage window:
   - `Test-WingetPackageInstalled` swallowed the launch exception and reported the **already-installed** Terminal as *not installed* (transcript line: `TerminatingError(Start-Process)` immediately before `Installing: Microsoft.WindowsTerminal`);
   - the #253 launch retry (3 attempts, 5s+10s = 15s) relaunched the **same broken alias** each time — far shorter than an App Installer registration window;
   - the post-verify and the entire final retry pass (30s later) failed the same way. The whole run lasted 50s; the outage outlasted it.

So the two compounding bugs were: the retry never resolved a *different* executable than the broken alias, and the backoff was an order of magnitude shorter than the outage it was meant to ride out.

## Fix

- **New private helper `WingetAppSetup/Private/WingetLaunchResilience.ps1`:**
  - `Test-TransientWingetLaunchError` — shared classification of the `ERROR_CANT_ACCESS_FILE` / `ERROR_SHARING_VIOLATION` launch exceptions (previously an inline regex in `Install-WingetPackage`).
  - `Resolve-WingetExecutable` — default returns `'winget'`; `-BypassAlias` resolves the registered `Microsoft.DesktopAppInstaller` package's own `winget.exe` via `Get-AppxPackage` (newest version first), bypassing the alias entirely — the documented workaround for alias-less contexts, and crucially `Get-AppxPackage` reports the *currently registered* package, so re-resolving converges on a launchable exe as soon as the upgraded package lands. Falls back to `'winget'` on any failure.
- **`Install-WingetPackage`:** launch failures get their own retry budget (`MaxLaunchAttempts`, default 5) with doubling backoff **5+10+20+40 = 75s** — sized to outlast an App Installer re-registration — and no longer consume `MaxAttempts` install attempts (no process ever ran). Each launch retry re-resolves via `Resolve-WingetExecutable -BypassAlias`. Result hashtable gains `LaunchAttempts`; `LaunchErrorExhausted`/null-`ExitCode` semantics unchanged.
- **`Test-WingetPackageInstalled` (timeout mode):** a transient launch failure is retried once through the alias bypass instead of being silently swallowed as "not installed" — the misclassification that turned an installed app into a reported install failure.
- `winget-app-install.ps1` regenerated (`build -Check` passes); CHANGELOG.md and STATUS.md updated.

## Testing

- New `tests/WingetLaunchResilience.Tests.ps1` (11 tests): transient-error classification incl. null/empty/case, and `Resolve-WingetExecutable` package resolution, newest-version preference, and all fallback paths.
- `tests/WingetCore.Tests.ps1` extended/updated: alias-bypass recovery in `Install-WingetPackage`, separate launch budget + 75s doubling-backoff schedule, exhaustion now reports `Attempts = 0` + `LaunchAttempts`, and two new `Test-WingetPackageInstalled` tests (bypass retry recovers an installed app; both-launches-fail keeps the no-throw contract).
- Local (Linux) run: all launch/backoff and timeout-mode Describes pass; the only added local failures are the `Get-AppxPackage`-mocking tests, which need Windows (same pre-existing pattern as the `Add-AppxPackage` tests) — the win-test Pester CI exercises them.

## Verification

After merge, re-dispatch the E2E workflow (`gh workflow run e2e-install.yml`) — it runs the true production `irm | iex` path from raw main twice; the second pass reproduces the WAU-collision timing that failed here and must exit 0 with every app Skipped.