### PR TITLE
fix: bound the PowerShell 7 MSI fallback so it cannot read as a hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the PowerShell 7 MSI fallback blocking indefinitely with no output, which reads as a hang
+  (issue #263). On a machine where the invoking account has no winget — the classic case being a
+  secondary admin account, since winget is a per-user MSIX — `Invoke-PowerShell7Bootstrap` handed
+  the whole install to `aka.ms/install-powershell.ps1 -UseMSI -Quiet` and went silent. That script
+  sets `$ProgressPreference = 'SilentlyContinue'` on Windows PowerShell, downloads the 110 MB MSI
+  with a bare `Invoke-WebRequest -OutFile` (which has **no read timeout** under 5.1), logs its
+  install step through a `Write-Verbose` that never prints, and waits on `msiexec` forever — so
+  between `About to download package from...` and the next visible line there was a 110 MB download
+  plus a full MSI install with zero output. Measured on a real link that is 3.5 minutes of silence
+  on a *healthy* run, and unbounded on a stalled one, with nothing to tell the two apart. The
+  bootstrap now downloads and installs the MSI itself first (`Install-PowerShell7FromMsi`), falling
+  back to the upstream script only if that fails: the release is resolved from the same
+  `tools/metadata.json` the upstream script reads (not the rate-limited GitHub releases API, whose
+  unauthenticated budget is per source IP and so is shared by everyone behind one office NAT), the
+  architecture comes from `PROCESSOR_ARCHITEW6432`/`PROCESSOR_ARCHITECTURE` rather than a
+  seconds-long `Get-ComputerInfo` call, and the download runs through the new
+  `Save-WebFileWithTimeout` — an `HttpWebRequest` whose `ReadWriteTimeout` bounds every individual
+  read on the response stream (the guarantee `Invoke-WebRequest` cannot give), plus an overall time
+  limit for a link that trickles without ever formally stalling, periodic `X of 110.2 MB (N%)`
+  progress lines, WinINET proxy credentials so an authenticating corporate proxy fails visibly
+  instead of looking like another stall, and a short-read check so a truncated MSI is reported here
+  rather than as an opaque msiexec failure. `msiexec /i <msi> /quiet /norestart` then runs under a
+  bounded `WaitForExit` (killed and reported on timeout, the usual cause being another install
+  holding the Windows Installer mutex), with exit code 3010 treated as success. The two
+  `Invoke-RestMethod` calls in the same function — the upstream-script fetch and the `irm | iex`
+  installer re-download — gained `-TimeoutSec` for the same reason. Verified against real Windows
+  PowerShell 5.1: a full 110.2 MB download completing byte-exact with a valid MSI header, the
+  overall-limit abort stopping a download mid-stream instead of hanging, and DNS-failure/404 paths
+  returning `$false` rather than throwing. This closes the gap issue #230 left open — the run no
+  longer *asks* anything, but it could still park forever with no way to tell slow from dead.
 - Fixed the winget launch retry never recovering when the `winget.exe` app-execution alias breaks
   mid-run (issue #258): E2E run 30253761253's second (idempotence) pass failed
   `Microsoft.WindowsTerminal` — an app that was already installed — because a background

--- a/STATUS.md
+++ b/STATUS.md
@@ -186,6 +186,7 @@ Pester installs persist across runs there ([#161](https://github.com/J-MaFf/wing
 |-------|-------------|--------|
 | [#258](https://github.com/J-MaFf/winget-app-setup/issues/258) | E2E install run failed: winget alias inaccessible through every launch retry (WAU/App Installer upgrade race) | In review — PR [#259](https://github.com/J-MaFf/winget-app-setup/pull/259) |
 | [#225](https://github.com/J-MaFf/winget-app-setup/issues/225) | Bootstrap PowerShell 7 from Windows PowerShell 5.1 instead of failing fast | In review — PR [#228](https://github.com/J-MaFf/winget-app-setup/pull/228) |
+| [#263](https://github.com/J-MaFf/winget-app-setup/issues/263) | PowerShell 7 MSI fallback blocks forever with no output (reads as a hang) | In review — PR [#264](https://github.com/J-MaFf/winget-app-setup/pull/264) |
 
 ## Natural Next Steps
 

--- a/WingetAppSetup/Private/PowerShell7Bootstrap.ps1
+++ b/WingetAppSetup/Private/PowerShell7Bootstrap.ps1
@@ -5,8 +5,10 @@
 # APIs, and only helpers that are themselves 5.1-safe. Currently that is: Write-Info/
 # Write-WarningMessage/Write-ErrorMessage/Write-Success (plain Write-Host wrappers), Test-IsAdmin
 # and its Get-CurrentWindowsPrincipal seam (Public/Elevation.ps1, Private/Elevation.ps1 - a
-# try/catch and a type cast, issue #239), and Get-WingetAgreementArgs (a literal array,
-# Private/WingetAgreementArgs.ps1, issue #240). Check any function added to this list - or any
+# try/catch and a type cast, issue #239), Get-WingetAgreementArgs (a literal array,
+# Private/WingetAgreementArgs.ps1, issue #240), and this file's own
+# Get-PowerShell7MsiInfo/Save-WebFileWithTimeout/Install-PowerShell7FromMsi (issue #263). Check
+# any function added to this list - or any
 # future edit to one already on it - against the same constraints before calling it from here; the
 # build's parse + ASCII guards only catch a parse-breaking token, not a PS7-only runtime construct
 # that still parses under 5.1 but behaves differently or throws. The build's parse + ASCII guards
@@ -88,6 +90,283 @@ function Find-PowerShell7 {
 
 <#
 .SYNOPSIS
+    Resolves the current stable PowerShell 7 release into an MSI download URL for this machine.
+.DESCRIPTION
+    Reads the same tools/metadata.json the official aka.ms/install-powershell.ps1 script reads
+    (issue #263), so the direct-download path below tracks whatever Microsoft currently ships
+    without this repo pinning a version that would go stale. That endpoint is a raw.githubusercontent
+    file rather than the GitHub releases API on purpose: the API's unauthenticated 60-requests-per-
+    hour budget is per source IP, which an office behind one NAT can exhaust for everyone.
+
+    Architecture comes from the environment rather than Get-ComputerInfo (which the upstream script
+    uses): Get-ComputerInfo takes seconds to populate every property just to read one, and it does
+    not exist before PowerShell 5.1. PROCESSOR_ARCHITEW6432 is checked first because a 32-bit host
+    process (some RMM agents) reports PROCESSOR_ARCHITECTURE as x86 on a 64-bit OS - the same
+    stale-view problem Find-PowerShell7 handles with ProgramW6432.
+.PARAMETER MetadataUrl
+    Release metadata endpoint. Parameterized for tests.
+.PARAMETER TimeoutSeconds
+    Maximum seconds to wait for the metadata request.
+.RETURNS
+    [hashtable] @{ Version; FileName; Url }, or $null when the release or architecture could not be
+    resolved (the caller then falls back to the upstream install script).
+#>
+function Get-PowerShell7MsiInfo {
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$MetadataUrl = 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json',
+        [Parameter(Mandatory = $false)]
+        [int]$TimeoutSeconds = 30
+    )
+
+    $architectureName = $env:PROCESSOR_ARCHITEW6432
+    if (-not $architectureName) {
+        $architectureName = $env:PROCESSOR_ARCHITECTURE
+    }
+    $architecture = $null
+    switch ($architectureName) {
+        'AMD64' { $architecture = 'x64' }
+        'ARM64' { $architecture = 'arm64' }
+        'x86' { $architecture = 'x86' }
+    }
+    if (-not $architecture) {
+        Write-WarningMessage ("Unrecognized processor architecture '{0}'; cannot pick a PowerShell 7 MSI." -f $architectureName)
+        return $null
+    }
+
+    $release = $null
+    try {
+        $metadata = Invoke-RestMethod -Uri $MetadataUrl -TimeoutSec $TimeoutSeconds
+        if ($metadata) {
+            $release = $metadata.ReleaseTag
+        }
+    }
+    catch {
+        Write-WarningMessage "Could not read the PowerShell release metadata: $_"
+        return $null
+    }
+    if (-not $release) {
+        Write-WarningMessage 'The PowerShell release metadata did not contain a ReleaseTag.'
+        return $null
+    }
+
+    $version = ($release -replace '^v', '')
+    $fileName = 'PowerShell-' + $version + '-win-' + $architecture + '.msi'
+    return @{
+        Version  = $version
+        FileName = $fileName
+        Url      = 'https://github.com/PowerShell/PowerShell/releases/download/v' + $version + '/' + $fileName
+    }
+}
+
+<#
+.SYNOPSIS
+    Downloads a URL to a file with a stall timeout, an overall time limit, and progress output.
+.DESCRIPTION
+    The reason this exists instead of Invoke-WebRequest -OutFile (issue #263). Under Windows
+    PowerShell 5.1 - the only engine this file ever runs on - Invoke-WebRequest has no read timeout,
+    so a proxy or link that accepts the connection and then stops sending blocks the pipeline
+    forever with no output and no error. That is exactly how the old MSI fallback failed: a 110 MB
+    download behind a suppressed progress bar was indistinguishable from a dead one.
+
+    HttpWebRequest's ReadWriteTimeout bounds every individual read on the response stream, which is
+    the guarantee Invoke-WebRequest cannot give. -MaximumSeconds additionally bounds a link that
+    trickles just fast enough to never trip the stall timeout, and the periodic progress line makes
+    a healthy slow download visibly different from a hung one.
+.PARAMETER Uri
+    Source URL.
+.PARAMETER DestinationPath
+    File to write. Its parent directory must already exist.
+.PARAMETER StallTimeoutSeconds
+    Maximum seconds the connection may go without delivering data before the download is abandoned.
+    Also bounds the initial connect/response phase.
+.PARAMETER MaximumSeconds
+    Maximum total seconds for the whole download.
+.PARAMETER ProgressIntervalSeconds
+    How often to print a progress line.
+.RETURNS
+    [bool] True when the file was written completely.
+#>
+function Save-WebFileWithTimeout {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Uri,
+        [Parameter(Mandatory = $true)]
+        [string]$DestinationPath,
+        [Parameter(Mandatory = $false)]
+        [int]$StallTimeoutSeconds = 60,
+        [Parameter(Mandatory = $false)]
+        [int]$MaximumSeconds = 900,
+        [Parameter(Mandatory = $false)]
+        [int]$ProgressIntervalSeconds = 10
+    )
+
+    $response = $null
+    $responseStream = $null
+    $fileStream = $null
+    try {
+        $request = [System.Net.HttpWebRequest][System.Net.WebRequest]::Create($Uri)
+        $request.Method = 'GET'
+        $request.Timeout = $StallTimeoutSeconds * 1000
+        $request.ReadWriteTimeout = $StallTimeoutSeconds * 1000
+        $request.UserAgent = 'winget-app-setup'
+        # Use the machine's configured (WinINET) proxy and authenticate to it as the current user.
+        # An authenticating corporate proxy that 407s otherwise looks like just another stall, and
+        # this bootstrap's whole job is to work on managed machines.
+        if ($request.Proxy) {
+            $request.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
+        }
+
+        $response = $request.GetResponse()
+        $totalBytes = $response.ContentLength
+        $totalText = 'unknown size'
+        if ($totalBytes -gt 0) {
+            $totalText = ('{0:N1} MB' -f ($totalBytes / 1MB))
+        }
+        Write-Info ('  Downloading {0}...' -f $totalText)
+
+        $responseStream = $response.GetResponseStream()
+        $fileStream = New-Object System.IO.FileStream($DestinationPath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write)
+        $buffer = New-Object byte[] 131072
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $lastReportSeconds = 0
+        $bytesReceived = 0
+
+        while ($true) {
+            $count = $responseStream.Read($buffer, 0, $buffer.Length)
+            if ($count -le 0) {
+                break
+            }
+            $fileStream.Write($buffer, 0, $count)
+            $bytesReceived = $bytesReceived + $count
+
+            $elapsedSeconds = $stopwatch.Elapsed.TotalSeconds
+            if ($elapsedSeconds -gt $MaximumSeconds) {
+                throw ('the download exceeded the {0}-second limit after {1:N1} MB' -f $MaximumSeconds, ($bytesReceived / 1MB))
+            }
+            if (($elapsedSeconds - $lastReportSeconds) -ge $ProgressIntervalSeconds) {
+                $lastReportSeconds = $elapsedSeconds
+                if ($totalBytes -gt 0) {
+                    Write-Info ('  {0:N1} MB of {1:N1} MB ({2:N0}%)' -f ($bytesReceived / 1MB), ($totalBytes / 1MB), (($bytesReceived / $totalBytes) * 100))
+                }
+                else {
+                    Write-Info ('  {0:N1} MB downloaded' -f ($bytesReceived / 1MB))
+                }
+            }
+        }
+
+        $fileStream.Close()
+        $fileStream = $null
+        # A truncated response still "completes" the read loop, and msiexec's failure on a partial
+        # MSI is far less legible than saying so here.
+        if ($totalBytes -gt 0 -and $bytesReceived -ne $totalBytes) {
+            Write-WarningMessage ('The download ended early: got {0:N1} MB of {1:N1} MB.' -f ($bytesReceived / 1MB), ($totalBytes / 1MB))
+            return $false
+        }
+        Write-Info ('  Downloaded {0:N1} MB in {1:N0}s.' -f ($bytesReceived / 1MB), $stopwatch.Elapsed.TotalSeconds)
+        return $true
+    }
+    catch {
+        Write-WarningMessage "The download failed: $_"
+        return $false
+    }
+    finally {
+        if ($fileStream) { try { $fileStream.Close() } catch { } }
+        if ($responseStream) { try { $responseStream.Close() } catch { } }
+        if ($response) { try { $response.Close() } catch { } }
+    }
+}
+
+<#
+.SYNOPSIS
+    Installs PowerShell 7 by downloading the official MSI and running msiexec, all time-bounded.
+.DESCRIPTION
+    Replaces blind delegation to aka.ms/install-powershell.ps1 -UseMSI -Quiet as the first-choice
+    fallback when winget is unavailable (issue #263). That script is not wrong, it is just opaque
+    and unbounded: it suppresses the progress bar on Windows PowerShell, downloads with an untimed
+    Invoke-WebRequest, logs its install step through a Write-Verbose that never prints, and waits on
+    msiexec forever. Doing the same two steps here buys the three things this bootstrap needs to
+    stay honest on an unattended run - visible progress, a bounded download, and a bounded install -
+    while the upstream script stays as the caller's last-resort fallback.
+
+    Exit code 3010 (ERROR_SUCCESS_REBOOT_REQUIRED) counts as success: pwsh.exe is on disk and
+    launchable at that point, and the relaunch does not need the pending reboot.
+.PARAMETER MetadataUrl
+    Forwarded to Get-PowerShell7MsiInfo. Parameterized for tests.
+.PARAMETER InstallTimeoutSeconds
+    Maximum seconds to wait for msiexec before killing it. The common cause of a long wait here is
+    another MSI install holding the Windows Installer mutex (msiexec 1618).
+.RETURNS
+    [bool] True when msiexec reported success. False sends the caller to the upstream script.
+#>
+function Install-PowerShell7FromMsi {
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$MetadataUrl = 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json',
+        [Parameter(Mandatory = $false)]
+        [int]$InstallTimeoutSeconds = 900
+    )
+
+    $msiInfo = Get-PowerShell7MsiInfo -MetadataUrl $MetadataUrl
+    if (-not $msiInfo) {
+        return $false
+    }
+
+    # Unique per-run directory for the same reason the relaunch path uses one: a predictable temp
+    # filename for a file this process is about to hand to an elevated msiexec is a swap target.
+    $downloadDirectory = Join-Path ([System.IO.Path]::GetTempPath()) ('winget-app-setup-pwsh-' + [System.Guid]::NewGuid().ToString('N'))
+    $msiPath = Join-Path $downloadDirectory $msiInfo.FileName
+    try {
+        [void](New-Item -Path $downloadDirectory -ItemType Directory -Force)
+    }
+    catch {
+        Write-WarningMessage "Could not create a temporary directory for the PowerShell 7 MSI: $_"
+        return $false
+    }
+
+    try {
+        Write-Info ('Downloading PowerShell {0} ({1})...' -f $msiInfo.Version, $msiInfo.FileName)
+        if (-not (Save-WebFileWithTimeout -Uri $msiInfo.Url -DestinationPath $msiPath)) {
+            return $false
+        }
+
+        Write-Info 'Installing PowerShell 7 (this takes about a minute)...'
+        $msiProcess = $null
+        try {
+            # Quoted because the MSI path contains a GUID-named directory under the user's temp
+            # path, which can sit under a profile directory containing spaces.
+            $msiArguments = @('/i', ('"' + $msiPath + '"'), '/quiet', '/norestart')
+            $msiProcess = Start-Process -FilePath 'msiexec.exe' -ArgumentList $msiArguments -PassThru -ErrorAction Stop
+        }
+        catch {
+            Write-WarningMessage "msiexec could not be started: $_"
+            return $false
+        }
+        if (-not $msiProcess) {
+            Write-WarningMessage 'msiexec could not be started.'
+            return $false
+        }
+
+        if (-not $msiProcess.WaitForExit($InstallTimeoutSeconds * 1000)) {
+            try { $msiProcess.Kill() } catch { }
+            Write-WarningMessage ('The PowerShell 7 MSI install did not finish within {0} seconds and was stopped. Another installation may be holding the Windows Installer service.' -f $InstallTimeoutSeconds)
+            return $false
+        }
+
+        $msiExitCode = $msiProcess.ExitCode
+        if ($msiExitCode -eq 0 -or $msiExitCode -eq 3010) {
+            return $true
+        }
+        Write-WarningMessage ('The PowerShell 7 MSI install failed (msiexec exit code {0}).' -f $msiExitCode)
+        return $false
+    }
+    finally {
+        Remove-Item -LiteralPath $downloadDirectory -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+<#
+.SYNOPSIS
     Finds or installs PowerShell 7, then relaunches the installer under pwsh in the same console.
 .DESCRIPTION
     The generated installer requires PowerShell 7+, but new machines ship with only Windows
@@ -98,8 +377,9 @@ function Find-PowerShell7 {
         1. Find an existing pwsh.exe (Find-PowerShell7). Present -> relaunch immediately; this
            alone fixes the "opened the built-in Windows PowerShell out of habit" case.
         2. Missing -> install it, no consent prompt (issue #230): winget first (an exe,
-           version-agnostic, preinstalled on consumer Windows 11), falling back to the official
-           aka.ms/install-powershell.ps1 MSI script when winget is absent or fails. -WhatIf never
+           version-agnostic, preinstalled on consumer Windows 11); when winget is absent or fails,
+           the official MSI downloaded and run directly by Install-PowerShell7FromMsi, with
+           aka.ms/install-powershell.ps1 behind that as a last resort (issue #263). -WhatIf never
            installs anything and previews the plan instead.
         3. Relaunch the installer under pwsh with -NoProfile -ExecutionPolicy Bypass in the SAME
            console (output and prompts stay in the caller's window), forwarding the caller's
@@ -222,15 +502,25 @@ function Invoke-PowerShell7Bootstrap {
         }
 
         if (-not $pwshPath) {
-            Write-Info 'Falling back to the official PowerShell MSI installer (https://aka.ms/install-powershell.ps1)...'
-            try {
-                $msiInstallScript = Invoke-RestMethod -Uri 'https://aka.ms/install-powershell.ps1'
-                # Out-Host: the downloaded script's pipeline output must not leak into this
-                # function's return value (the tail dispatch exits with it).
-                & ([ScriptBlock]::Create($msiInstallScript)) -UseMSI -Quiet | Out-Host
-            }
-            catch {
-                Write-WarningMessage "The MSI fallback failed: $_"
+            # Direct MSI first, upstream script only if that fails (issue #263). Delegating
+            # straight to aka.ms/install-powershell.ps1 used to park the console for minutes with
+            # no output whatsoever - see Install-PowerShell7FromMsi's help for why - which on a
+            # stalled link is indistinguishable from the run having died. Doing the download here
+            # makes progress visible and both steps time-bounded.
+            Write-Info 'Falling back to the official PowerShell MSI installer...'
+            if (-not (Install-PowerShell7FromMsi)) {
+                Write-WarningMessage 'Falling back to the official installer script (https://aka.ms/install-powershell.ps1). It reports no download progress, so this step can run for several minutes with no output.'
+                try {
+                    # -TimeoutSec bounds the script download itself; the script's own MSI download
+                    # is the unbounded part this path accepts as a last resort.
+                    $msiInstallScript = Invoke-RestMethod -Uri 'https://aka.ms/install-powershell.ps1' -TimeoutSec 60
+                    # Out-Host: the downloaded script's pipeline output must not leak into this
+                    # function's return value (the tail dispatch exits with it).
+                    & ([ScriptBlock]::Create($msiInstallScript)) -UseMSI -Quiet | Out-Host
+                }
+                catch {
+                    Write-WarningMessage "The MSI fallback failed: $_"
+                }
             }
             $pwshPath = Find-PowerShell7
         }
@@ -246,7 +536,7 @@ function Invoke-PowerShell7Bootstrap {
     if (-not $relaunchPath) {
         Write-Info 'Downloading the installer for the PowerShell 7 relaunch...'
         try {
-            $installerContent = Invoke-RestMethod -Uri $InstallerUrl
+            $installerContent = Invoke-RestMethod -Uri $InstallerUrl -TimeoutSec 60
             # Unique per-run directory (issue #225 review): a fixed temp filename could be
             # pre-planted or swapped by another same-user process before the relaunch - which
             # matters extra here because the relaunched run may self-elevate from this very path -

--- a/WingetAppSetup/Private/PowerShell7Bootstrap.ps1
+++ b/WingetAppSetup/Private/PowerShell7Bootstrap.ps1
@@ -317,7 +317,10 @@ function Install-PowerShell7FromMsi {
     $downloadDirectory = Join-Path ([System.IO.Path]::GetTempPath()) ('winget-app-setup-pwsh-' + [System.Guid]::NewGuid().ToString('N'))
     $msiPath = Join-Path $downloadDirectory $msiInfo.FileName
     try {
-        [void](New-Item -Path $downloadDirectory -ItemType Directory -Force)
+        # -ErrorAction Stop, without which this catch would be decorative: a New-Item failure is
+        # non-terminating under 5.1's default preference, so the run would continue to a download
+        # into a directory that does not exist and report the far less legible stream error.
+        [void](New-Item -Path $downloadDirectory -ItemType Directory -Force -ErrorAction Stop)
     }
     catch {
         Write-WarningMessage "Could not create a temporary directory for the PowerShell 7 MSI: $_"

--- a/tests/PowerShell7Bootstrap.Tests.ps1
+++ b/tests/PowerShell7Bootstrap.Tests.ps1
@@ -326,6 +326,15 @@ Describe 'Install-PowerShell7FromMsi' {
         Should -Invoke Remove-Item -Times 1 -Exactly -ParameterFilter { $LiteralPath -like '*winget-app-setup-pwsh-*' }
     }
 
+    It 'Never downloads when the temp directory cannot be created' {
+        Mock New-Item { throw 'Access to the path is denied.' }
+
+        Install-PowerShell7FromMsi | Should -Be $false
+        Should -Invoke Save-WebFileWithTimeout -Times 0
+        Should -Invoke Start-Process -Times 0
+        Should -Invoke Write-WarningMessage -Times 1 -ParameterFilter { $Message -match 'temporary directory' }
+    }
+
     It 'Never downloads when the release cannot be resolved' {
         Mock Get-PowerShell7MsiInfo { $null }
 

--- a/tests/PowerShell7Bootstrap.Tests.ps1
+++ b/tests/PowerShell7Bootstrap.Tests.ps1
@@ -137,6 +137,213 @@ Describe 'Find-PowerShell7' {
     }
 }
 
+Describe 'Get-PowerShell7MsiInfo' {
+    BeforeEach {
+        Mock Write-WarningMessage { }
+        Mock Invoke-RestMethod { [pscustomobject]@{ ReleaseTag = 'v7.6.4' } }
+        $script:savedArchitecture = $env:PROCESSOR_ARCHITECTURE
+        $script:savedArchitectureW6432 = $env:PROCESSOR_ARCHITEW6432
+        $env:PROCESSOR_ARCHITECTURE = 'AMD64'
+        $env:PROCESSOR_ARCHITEW6432 = ''
+    }
+    AfterEach {
+        $env:PROCESSOR_ARCHITECTURE = $script:savedArchitecture
+        $env:PROCESSOR_ARCHITEW6432 = $script:savedArchitectureW6432
+    }
+
+    It 'Builds the x64 MSI url from the release metadata' {
+        $info = Get-PowerShell7MsiInfo
+
+        $info.Version | Should -Be '7.6.4'
+        $info.FileName | Should -Be 'PowerShell-7.6.4-win-x64.msi'
+        $info.Url | Should -Be 'https://github.com/PowerShell/PowerShell/releases/download/v7.6.4/PowerShell-7.6.4-win-x64.msi'
+    }
+
+    It 'Bounds the metadata request with a timeout' {
+        # The whole point of issue #263: no request on this path may be able to block forever.
+        Get-PowerShell7MsiInfo | Out-Null
+
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $TimeoutSec -gt 0
+        }
+    }
+
+    It 'Honors a custom MetadataUrl' {
+        Get-PowerShell7MsiInfo -MetadataUrl 'https://example.test/metadata.json' | Out-Null
+
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter { $Uri -eq 'https://example.test/metadata.json' }
+    }
+
+    It 'Resolves arm64' {
+        $env:PROCESSOR_ARCHITECTURE = 'ARM64'
+
+        (Get-PowerShell7MsiInfo).FileName | Should -Be 'PowerShell-7.6.4-win-arm64.msi'
+    }
+
+    It 'Prefers PROCESSOR_ARCHITEW6432 so a 32-bit host does not pick the x86 MSI' {
+        # A 32-bit host process (some RMM agents) reports x86 on a 64-bit OS - the same stale-view
+        # problem Find-PowerShell7 handles with ProgramW6432.
+        $env:PROCESSOR_ARCHITECTURE = 'x86'
+        $env:PROCESSOR_ARCHITEW6432 = 'AMD64'
+
+        (Get-PowerShell7MsiInfo).FileName | Should -Be 'PowerShell-7.6.4-win-x64.msi'
+    }
+
+    It 'Uses the x86 MSI on a genuinely 32-bit OS' {
+        $env:PROCESSOR_ARCHITECTURE = 'x86'
+        $env:PROCESSOR_ARCHITEW6432 = ''
+
+        (Get-PowerShell7MsiInfo).FileName | Should -Be 'PowerShell-7.6.4-win-x86.msi'
+    }
+
+    It 'Returns $null for an unrecognized architecture without calling the network' {
+        $env:PROCESSOR_ARCHITECTURE = 'IA64'
+
+        Get-PowerShell7MsiInfo | Should -BeNullOrEmpty
+        Should -Invoke Invoke-RestMethod -Times 0
+    }
+
+    It 'Returns $null when the metadata request fails' {
+        Mock Invoke-RestMethod { throw 'network unreachable' }
+
+        Get-PowerShell7MsiInfo | Should -BeNullOrEmpty
+    }
+
+    It 'Returns $null when the metadata carries no ReleaseTag' {
+        Mock Invoke-RestMethod { [pscustomobject]@{ PreviewReleaseTag = 'v7.7.0-preview.1' } }
+
+        Get-PowerShell7MsiInfo | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Save-WebFileWithTimeout' {
+    BeforeEach {
+        Mock Write-Info { }
+        Mock Write-WarningMessage { }
+    }
+
+    It 'Returns $false instead of throwing when the request cannot even be created' {
+        Save-WebFileWithTimeout -Uri 'not-a-url' -DestinationPath (Join-Path $TestDrive 'out.bin') | Should -Be $false
+        Should -Invoke Write-WarningMessage -Times 1 -ParameterFilter { $Message -match 'download failed' }
+    }
+
+    It 'Returns $false when the host cannot be resolved' {
+        # Bounded by the request timeout rather than hanging - the defect issue #263 exists for.
+        Save-WebFileWithTimeout -Uri 'https://no-such-host.invalid/file.msi' -DestinationPath (Join-Path $TestDrive 'out.bin') -StallTimeoutSeconds 5 -MaximumSeconds 15 |
+            Should -Be $false
+    }
+}
+
+Describe 'Install-PowerShell7FromMsi' {
+    BeforeEach {
+        Mock Write-Info { }
+        Mock Write-WarningMessage { }
+        Mock New-Item { }
+        Mock Remove-Item { }
+        Mock Get-PowerShell7MsiInfo {
+            @{
+                Version  = '7.6.4'
+                FileName = 'PowerShell-7.6.4-win-x64.msi'
+                Url      = 'https://example.test/PowerShell-7.6.4-win-x64.msi'
+            }
+        }
+        Mock Save-WebFileWithTimeout { $true }
+
+        # msiexec stand-in. Start-Process -PassThru returns a real Process, so the double needs the
+        # two members production reads (WaitForExit/ExitCode) plus Kill for the timeout path.
+        $script:msiExited = $true
+        $script:msiExitCode = 0
+        $script:msiKilled = $false
+        $script:msiProcess = [pscustomobject]@{}
+        $script:msiProcess | Add-Member -MemberType ScriptProperty -Name ExitCode -Value { $script:msiExitCode }
+        $script:msiProcess | Add-Member -MemberType ScriptMethod -Name WaitForExit -Value { param($Milliseconds) return $script:msiExited }
+        $script:msiProcess | Add-Member -MemberType ScriptMethod -Name Kill -Value { $script:msiKilled = $true }
+        Mock Start-Process { $script:msiProcess } -ParameterFilter { $FilePath -eq 'msiexec.exe' }
+    }
+
+    It 'Downloads the resolved MSI and installs it quietly' {
+        Install-PowerShell7FromMsi | Should -Be $true
+
+        Should -Invoke Save-WebFileWithTimeout -Times 1 -Exactly -ParameterFilter {
+            $Uri -eq 'https://example.test/PowerShell-7.6.4-win-x64.msi' -and
+            $DestinationPath -like '*winget-app-setup-pwsh-*PowerShell-7.6.4-win-x64.msi'
+        }
+        Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter {
+            $FilePath -eq 'msiexec.exe' -and
+            $ArgumentList -contains '/i' -and
+            $ArgumentList -contains '/quiet' -and
+            $ArgumentList -contains '/norestart'
+        }
+    }
+
+    It 'Downloads into a unique per-run directory, then removes it' {
+        Install-PowerShell7FromMsi | Out-Null
+
+        Should -Invoke New-Item -Times 1 -Exactly -ParameterFilter { $Path -like '*winget-app-setup-pwsh-*' }
+        Should -Invoke Remove-Item -Times 1 -Exactly -ParameterFilter { $LiteralPath -like '*winget-app-setup-pwsh-*' }
+    }
+
+    It 'Treats msiexec 3010 (reboot required) as success' {
+        # pwsh.exe is on disk and launchable at that point; the relaunch does not need the reboot.
+        $script:msiExitCode = 3010
+
+        Install-PowerShell7FromMsi | Should -Be $true
+    }
+
+    It 'Returns $false on a nonzero msiexec exit code' {
+        $script:msiExitCode = 1618
+
+        Install-PowerShell7FromMsi | Should -Be $false
+        Should -Invoke Write-WarningMessage -Times 1 -ParameterFilter { $Message -match '1618' }
+    }
+
+    It 'Kills msiexec and returns $false when the install outruns the timeout' {
+        $script:msiExited = $false
+
+        Install-PowerShell7FromMsi -InstallTimeoutSeconds 5 | Should -Be $false
+        $script:msiKilled | Should -Be $true
+        Should -Invoke Write-WarningMessage -Times 1 -ParameterFilter { $Message -match 'did not finish within 5 seconds' }
+    }
+
+    It 'Passes the install timeout to WaitForExit in milliseconds' {
+        $script:waitMilliseconds = $null
+        $script:msiProcess | Add-Member -MemberType ScriptMethod -Name WaitForExit -Force -Value {
+            param($Milliseconds)
+            $script:waitMilliseconds = $Milliseconds
+            return $true
+        }
+
+        Install-PowerShell7FromMsi -InstallTimeoutSeconds 42 | Out-Null
+
+        $script:waitMilliseconds | Should -Be 42000
+    }
+
+    It 'Never runs msiexec when the download fails' {
+        Mock Save-WebFileWithTimeout { $false }
+
+        Install-PowerShell7FromMsi | Should -Be $false
+        Should -Invoke Start-Process -Times 0
+        Should -Invoke Remove-Item -Times 1 -Exactly -ParameterFilter { $LiteralPath -like '*winget-app-setup-pwsh-*' }
+    }
+
+    It 'Never downloads when the release cannot be resolved' {
+        Mock Get-PowerShell7MsiInfo { $null }
+
+        Install-PowerShell7FromMsi | Should -Be $false
+        Should -Invoke Save-WebFileWithTimeout -Times 0
+        Should -Invoke Start-Process -Times 0
+    }
+
+    It 'Returns $false when msiexec cannot be started' {
+        # Under 5.1 a Start-Process failure is non-terminating, so without production's try/catch
+        # $msiProcess would stay $null and the ExitCode read would blow up mid-bootstrap.
+        Mock Start-Process { throw 'The system cannot find the file specified.' } -ParameterFilter { $FilePath -eq 'msiexec.exe' }
+
+        Install-PowerShell7FromMsi | Should -Be $false
+        Should -Invoke Write-WarningMessage -Times 1 -ParameterFilter { $Message -match 'msiexec could not be started' }
+    }
+}
+
 Describe 'Invoke-PowerShell7Bootstrap' {
     BeforeEach {
         # Quiet the console helpers; every path is asserted through mocks, not output.
@@ -145,6 +352,10 @@ Describe 'Invoke-PowerShell7Bootstrap' {
         Mock Write-ErrorMessage { }
         Mock Write-Success { }
         Mock Invoke-RestMethod { '# stub' }
+        # Default the direct-MSI path to "did not work" so the pre-existing tests below keep
+        # exercising the upstream-script fallback deterministically, with no real network reachable
+        # from any of them. The direct path has its own context further down.
+        Mock Install-PowerShell7FromMsi { $false }
         # The function sets this relaunch-loop sentinel before relaunching; clear it so no test
         # inherits another test's (or an outer process's) bootstrap state.
         $env:WINGET_APP_SETUP_PS7_BOOTSTRAP = ''
@@ -344,6 +555,63 @@ Describe 'Invoke-PowerShell7Bootstrap' {
         }
     }
 
+    Context 'PowerShell 7 missing, direct MSI download (issue #263)' {
+        BeforeEach {
+            $script:findCallCount = 0
+            Mock Find-PowerShell7 {
+                $script:findCallCount++
+                if ($script:findCallCount -ge 2) {
+                    return 'C:\pf7\pwsh.exe'
+                }
+                return $null
+            }
+            Mock Get-Command { $null } -ParameterFilter { $Name -eq 'winget' }
+            Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } } -ParameterFilter { $FilePath -eq 'C:\pf7\pwsh.exe' }
+        }
+
+        It 'Installs via the bounded direct MSI path and never touches the upstream script' {
+            # The regression this guards: the upstream script suppresses all download progress and
+            # downloads with an untimed Invoke-WebRequest, so reaching it is the slow, silent,
+            # unbounded path. It must now only run when the direct path has already failed.
+            Mock Install-PowerShell7FromMsi { $true }
+
+            $result = Invoke-PowerShell7Bootstrap -CommandPath 'C:\repo\winget-app-install.ps1'
+
+            $result | Should -Be 0
+            Should -Invoke Install-PowerShell7FromMsi -Times 1 -Exactly
+            Should -Invoke Invoke-RestMethod -Times 0 -ParameterFilter { $Uri -like '*install-powershell*' }
+        }
+
+        It 'Falls through to the upstream script only when the direct path fails' {
+            Mock Install-PowerShell7FromMsi { $false }
+
+            Invoke-PowerShell7Bootstrap -CommandPath 'C:\repo\winget-app-install.ps1' | Out-Null
+
+            Should -Invoke Install-PowerShell7FromMsi -Times 1 -Exactly
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter { $Uri -like '*install-powershell*' }
+        }
+
+        It 'Warns that the upstream script produces no output before handing off to it' {
+            # Silence is the whole complaint in issue #263; if this path is still reachable, the
+            # operator has to be told that no output is expected rather than inferring a hang.
+            Mock Install-PowerShell7FromMsi { $false }
+
+            Invoke-PowerShell7Bootstrap -CommandPath 'C:\repo\winget-app-install.ps1' | Out-Null
+
+            Should -Invoke Write-WarningMessage -Times 1 -ParameterFilter { $Message -match 'no download progress' }
+        }
+
+        It 'Bounds the upstream script download with a timeout' {
+            Mock Install-PowerShell7FromMsi { $false }
+
+            Invoke-PowerShell7Bootstrap -CommandPath 'C:\repo\winget-app-install.ps1' | Out-Null
+
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+                $Uri -like '*install-powershell*' -and $TimeoutSec -gt 0
+            }
+        }
+    }
+
     Context 'PowerShell 7 missing, MSI fallback' {
         BeforeEach {
             Mock Test-EffectiveNonInteractive { $true }
@@ -440,6 +708,14 @@ Describe 'Invoke-PowerShell7Bootstrap' {
             Invoke-PowerShell7Bootstrap -InstallerUrl 'https://example.test/custom.ps1' | Out-Null
 
             Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter { $Uri -eq 'https://example.test/custom.ps1' }
+        }
+
+        It 'Bounds the re-download with a timeout (issue #263)' {
+            Mock Invoke-RestMethod { '# installer body' }
+
+            Invoke-PowerShell7Bootstrap | Out-Null
+
+            Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter { $TimeoutSec -gt 0 }
         }
 
         It 'Returns 1 when the re-download fails' {

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -58,12 +58,12 @@ param (
 # This script is assembled from the WingetAppSetup module by build/Build-WingetInstallScript.ps1.
 # Edit the function source under WingetAppSetup/Public and WingetAppSetup/Private, then re-run the
 # build to regenerate this file. See readme.md ("Project layout") for details.
-# Build id: 1.0.0+94e65293 (module version + SHA256 fragment of the function content; issue #189).
+# Build id: 1.0.0+45fed6f6 (module version + SHA256 fragment of the function content; issue #189).
 # ------------------------------------------------------------------------------------------------
 
 # Content-derived build identity, logged at startup so a transcript from a remote machine
 # identifies exactly which installer build produced it (issue #189).
-$script:InstallerBuildId = '1.0.0+94e65293'
+$script:InstallerBuildId = '1.0.0+45fed6f6'
 
 # ------------------------------------------------Functions------------------------------------------------
 
@@ -1147,7 +1147,10 @@ function Install-PowerShell7FromMsi {
     $downloadDirectory = Join-Path ([System.IO.Path]::GetTempPath()) ('winget-app-setup-pwsh-' + [System.Guid]::NewGuid().ToString('N'))
     $msiPath = Join-Path $downloadDirectory $msiInfo.FileName
     try {
-        [void](New-Item -Path $downloadDirectory -ItemType Directory -Force)
+        # -ErrorAction Stop, without which this catch would be decorative: a New-Item failure is
+        # non-terminating under 5.1's default preference, so the run would continue to a download
+        # into a directory that does not exist and report the far less legible stream error.
+        [void](New-Item -Path $downloadDirectory -ItemType Directory -Force -ErrorAction Stop)
     }
     catch {
         Write-WarningMessage "Could not create a temporary directory for the PowerShell 7 MSI: $_"

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -58,12 +58,12 @@ param (
 # This script is assembled from the WingetAppSetup module by build/Build-WingetInstallScript.ps1.
 # Edit the function source under WingetAppSetup/Public and WingetAppSetup/Private, then re-run the
 # build to regenerate this file. See readme.md ("Project layout") for details.
-# Build id: 1.0.0+40fcd2ea (module version + SHA256 fragment of the function content; issue #189).
+# Build id: 1.0.0+94e65293 (module version + SHA256 fragment of the function content; issue #189).
 # ------------------------------------------------------------------------------------------------
 
 # Content-derived build identity, logged at startup so a transcript from a remote machine
 # identifies exactly which installer build produced it (issue #189).
-$script:InstallerBuildId = '1.0.0+40fcd2ea'
+$script:InstallerBuildId = '1.0.0+94e65293'
 
 # ------------------------------------------------Functions------------------------------------------------
 
@@ -835,8 +835,10 @@ function Test-WingetListOutputContainsPackageId {
 # APIs, and only helpers that are themselves 5.1-safe. Currently that is: Write-Info/
 # Write-WarningMessage/Write-ErrorMessage/Write-Success (plain Write-Host wrappers), Test-IsAdmin
 # and its Get-CurrentWindowsPrincipal seam (Public/Elevation.ps1, Private/Elevation.ps1 - a
-# try/catch and a type cast, issue #239), and Get-WingetAgreementArgs (a literal array,
-# Private/WingetAgreementArgs.ps1, issue #240). Check any function added to this list - or any
+# try/catch and a type cast, issue #239), Get-WingetAgreementArgs (a literal array,
+# Private/WingetAgreementArgs.ps1, issue #240), and this file's own
+# Get-PowerShell7MsiInfo/Save-WebFileWithTimeout/Install-PowerShell7FromMsi (issue #263). Check
+# any function added to this list - or any
 # future edit to one already on it - against the same constraints before calling it from here; the
 # build's parse + ASCII guards only catch a parse-breaking token, not a PS7-only runtime construct
 # that still parses under 5.1 but behaves differently or throws. The build's parse + ASCII guards
@@ -918,6 +920,283 @@ function Find-PowerShell7 {
 
 <#
 .SYNOPSIS
+    Resolves the current stable PowerShell 7 release into an MSI download URL for this machine.
+.DESCRIPTION
+    Reads the same tools/metadata.json the official aka.ms/install-powershell.ps1 script reads
+    (issue #263), so the direct-download path below tracks whatever Microsoft currently ships
+    without this repo pinning a version that would go stale. That endpoint is a raw.githubusercontent
+    file rather than the GitHub releases API on purpose: the API's unauthenticated 60-requests-per-
+    hour budget is per source IP, which an office behind one NAT can exhaust for everyone.
+
+    Architecture comes from the environment rather than Get-ComputerInfo (which the upstream script
+    uses): Get-ComputerInfo takes seconds to populate every property just to read one, and it does
+    not exist before PowerShell 5.1. PROCESSOR_ARCHITEW6432 is checked first because a 32-bit host
+    process (some RMM agents) reports PROCESSOR_ARCHITECTURE as x86 on a 64-bit OS - the same
+    stale-view problem Find-PowerShell7 handles with ProgramW6432.
+.PARAMETER MetadataUrl
+    Release metadata endpoint. Parameterized for tests.
+.PARAMETER TimeoutSeconds
+    Maximum seconds to wait for the metadata request.
+.RETURNS
+    [hashtable] @{ Version; FileName; Url }, or $null when the release or architecture could not be
+    resolved (the caller then falls back to the upstream install script).
+#>
+function Get-PowerShell7MsiInfo {
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$MetadataUrl = 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json',
+        [Parameter(Mandatory = $false)]
+        [int]$TimeoutSeconds = 30
+    )
+
+    $architectureName = $env:PROCESSOR_ARCHITEW6432
+    if (-not $architectureName) {
+        $architectureName = $env:PROCESSOR_ARCHITECTURE
+    }
+    $architecture = $null
+    switch ($architectureName) {
+        'AMD64' { $architecture = 'x64' }
+        'ARM64' { $architecture = 'arm64' }
+        'x86' { $architecture = 'x86' }
+    }
+    if (-not $architecture) {
+        Write-WarningMessage ("Unrecognized processor architecture '{0}'; cannot pick a PowerShell 7 MSI." -f $architectureName)
+        return $null
+    }
+
+    $release = $null
+    try {
+        $metadata = Invoke-RestMethod -Uri $MetadataUrl -TimeoutSec $TimeoutSeconds
+        if ($metadata) {
+            $release = $metadata.ReleaseTag
+        }
+    }
+    catch {
+        Write-WarningMessage "Could not read the PowerShell release metadata: $_"
+        return $null
+    }
+    if (-not $release) {
+        Write-WarningMessage 'The PowerShell release metadata did not contain a ReleaseTag.'
+        return $null
+    }
+
+    $version = ($release -replace '^v', '')
+    $fileName = 'PowerShell-' + $version + '-win-' + $architecture + '.msi'
+    return @{
+        Version  = $version
+        FileName = $fileName
+        Url      = 'https://github.com/PowerShell/PowerShell/releases/download/v' + $version + '/' + $fileName
+    }
+}
+
+<#
+.SYNOPSIS
+    Downloads a URL to a file with a stall timeout, an overall time limit, and progress output.
+.DESCRIPTION
+    The reason this exists instead of Invoke-WebRequest -OutFile (issue #263). Under Windows
+    PowerShell 5.1 - the only engine this file ever runs on - Invoke-WebRequest has no read timeout,
+    so a proxy or link that accepts the connection and then stops sending blocks the pipeline
+    forever with no output and no error. That is exactly how the old MSI fallback failed: a 110 MB
+    download behind a suppressed progress bar was indistinguishable from a dead one.
+
+    HttpWebRequest's ReadWriteTimeout bounds every individual read on the response stream, which is
+    the guarantee Invoke-WebRequest cannot give. -MaximumSeconds additionally bounds a link that
+    trickles just fast enough to never trip the stall timeout, and the periodic progress line makes
+    a healthy slow download visibly different from a hung one.
+.PARAMETER Uri
+    Source URL.
+.PARAMETER DestinationPath
+    File to write. Its parent directory must already exist.
+.PARAMETER StallTimeoutSeconds
+    Maximum seconds the connection may go without delivering data before the download is abandoned.
+    Also bounds the initial connect/response phase.
+.PARAMETER MaximumSeconds
+    Maximum total seconds for the whole download.
+.PARAMETER ProgressIntervalSeconds
+    How often to print a progress line.
+.RETURNS
+    [bool] True when the file was written completely.
+#>
+function Save-WebFileWithTimeout {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Uri,
+        [Parameter(Mandatory = $true)]
+        [string]$DestinationPath,
+        [Parameter(Mandatory = $false)]
+        [int]$StallTimeoutSeconds = 60,
+        [Parameter(Mandatory = $false)]
+        [int]$MaximumSeconds = 900,
+        [Parameter(Mandatory = $false)]
+        [int]$ProgressIntervalSeconds = 10
+    )
+
+    $response = $null
+    $responseStream = $null
+    $fileStream = $null
+    try {
+        $request = [System.Net.HttpWebRequest][System.Net.WebRequest]::Create($Uri)
+        $request.Method = 'GET'
+        $request.Timeout = $StallTimeoutSeconds * 1000
+        $request.ReadWriteTimeout = $StallTimeoutSeconds * 1000
+        $request.UserAgent = 'winget-app-setup'
+        # Use the machine's configured (WinINET) proxy and authenticate to it as the current user.
+        # An authenticating corporate proxy that 407s otherwise looks like just another stall, and
+        # this bootstrap's whole job is to work on managed machines.
+        if ($request.Proxy) {
+            $request.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
+        }
+
+        $response = $request.GetResponse()
+        $totalBytes = $response.ContentLength
+        $totalText = 'unknown size'
+        if ($totalBytes -gt 0) {
+            $totalText = ('{0:N1} MB' -f ($totalBytes / 1MB))
+        }
+        Write-Info ('  Downloading {0}...' -f $totalText)
+
+        $responseStream = $response.GetResponseStream()
+        $fileStream = New-Object System.IO.FileStream($DestinationPath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write)
+        $buffer = New-Object byte[] 131072
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $lastReportSeconds = 0
+        $bytesReceived = 0
+
+        while ($true) {
+            $count = $responseStream.Read($buffer, 0, $buffer.Length)
+            if ($count -le 0) {
+                break
+            }
+            $fileStream.Write($buffer, 0, $count)
+            $bytesReceived = $bytesReceived + $count
+
+            $elapsedSeconds = $stopwatch.Elapsed.TotalSeconds
+            if ($elapsedSeconds -gt $MaximumSeconds) {
+                throw ('the download exceeded the {0}-second limit after {1:N1} MB' -f $MaximumSeconds, ($bytesReceived / 1MB))
+            }
+            if (($elapsedSeconds - $lastReportSeconds) -ge $ProgressIntervalSeconds) {
+                $lastReportSeconds = $elapsedSeconds
+                if ($totalBytes -gt 0) {
+                    Write-Info ('  {0:N1} MB of {1:N1} MB ({2:N0}%)' -f ($bytesReceived / 1MB), ($totalBytes / 1MB), (($bytesReceived / $totalBytes) * 100))
+                }
+                else {
+                    Write-Info ('  {0:N1} MB downloaded' -f ($bytesReceived / 1MB))
+                }
+            }
+        }
+
+        $fileStream.Close()
+        $fileStream = $null
+        # A truncated response still "completes" the read loop, and msiexec's failure on a partial
+        # MSI is far less legible than saying so here.
+        if ($totalBytes -gt 0 -and $bytesReceived -ne $totalBytes) {
+            Write-WarningMessage ('The download ended early: got {0:N1} MB of {1:N1} MB.' -f ($bytesReceived / 1MB), ($totalBytes / 1MB))
+            return $false
+        }
+        Write-Info ('  Downloaded {0:N1} MB in {1:N0}s.' -f ($bytesReceived / 1MB), $stopwatch.Elapsed.TotalSeconds)
+        return $true
+    }
+    catch {
+        Write-WarningMessage "The download failed: $_"
+        return $false
+    }
+    finally {
+        if ($fileStream) { try { $fileStream.Close() } catch { } }
+        if ($responseStream) { try { $responseStream.Close() } catch { } }
+        if ($response) { try { $response.Close() } catch { } }
+    }
+}
+
+<#
+.SYNOPSIS
+    Installs PowerShell 7 by downloading the official MSI and running msiexec, all time-bounded.
+.DESCRIPTION
+    Replaces blind delegation to aka.ms/install-powershell.ps1 -UseMSI -Quiet as the first-choice
+    fallback when winget is unavailable (issue #263). That script is not wrong, it is just opaque
+    and unbounded: it suppresses the progress bar on Windows PowerShell, downloads with an untimed
+    Invoke-WebRequest, logs its install step through a Write-Verbose that never prints, and waits on
+    msiexec forever. Doing the same two steps here buys the three things this bootstrap needs to
+    stay honest on an unattended run - visible progress, a bounded download, and a bounded install -
+    while the upstream script stays as the caller's last-resort fallback.
+
+    Exit code 3010 (ERROR_SUCCESS_REBOOT_REQUIRED) counts as success: pwsh.exe is on disk and
+    launchable at that point, and the relaunch does not need the pending reboot.
+.PARAMETER MetadataUrl
+    Forwarded to Get-PowerShell7MsiInfo. Parameterized for tests.
+.PARAMETER InstallTimeoutSeconds
+    Maximum seconds to wait for msiexec before killing it. The common cause of a long wait here is
+    another MSI install holding the Windows Installer mutex (msiexec 1618).
+.RETURNS
+    [bool] True when msiexec reported success. False sends the caller to the upstream script.
+#>
+function Install-PowerShell7FromMsi {
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$MetadataUrl = 'https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json',
+        [Parameter(Mandatory = $false)]
+        [int]$InstallTimeoutSeconds = 900
+    )
+
+    $msiInfo = Get-PowerShell7MsiInfo -MetadataUrl $MetadataUrl
+    if (-not $msiInfo) {
+        return $false
+    }
+
+    # Unique per-run directory for the same reason the relaunch path uses one: a predictable temp
+    # filename for a file this process is about to hand to an elevated msiexec is a swap target.
+    $downloadDirectory = Join-Path ([System.IO.Path]::GetTempPath()) ('winget-app-setup-pwsh-' + [System.Guid]::NewGuid().ToString('N'))
+    $msiPath = Join-Path $downloadDirectory $msiInfo.FileName
+    try {
+        [void](New-Item -Path $downloadDirectory -ItemType Directory -Force)
+    }
+    catch {
+        Write-WarningMessage "Could not create a temporary directory for the PowerShell 7 MSI: $_"
+        return $false
+    }
+
+    try {
+        Write-Info ('Downloading PowerShell {0} ({1})...' -f $msiInfo.Version, $msiInfo.FileName)
+        if (-not (Save-WebFileWithTimeout -Uri $msiInfo.Url -DestinationPath $msiPath)) {
+            return $false
+        }
+
+        Write-Info 'Installing PowerShell 7 (this takes about a minute)...'
+        $msiProcess = $null
+        try {
+            # Quoted because the MSI path contains a GUID-named directory under the user's temp
+            # path, which can sit under a profile directory containing spaces.
+            $msiArguments = @('/i', ('"' + $msiPath + '"'), '/quiet', '/norestart')
+            $msiProcess = Start-Process -FilePath 'msiexec.exe' -ArgumentList $msiArguments -PassThru -ErrorAction Stop
+        }
+        catch {
+            Write-WarningMessage "msiexec could not be started: $_"
+            return $false
+        }
+        if (-not $msiProcess) {
+            Write-WarningMessage 'msiexec could not be started.'
+            return $false
+        }
+
+        if (-not $msiProcess.WaitForExit($InstallTimeoutSeconds * 1000)) {
+            try { $msiProcess.Kill() } catch { }
+            Write-WarningMessage ('The PowerShell 7 MSI install did not finish within {0} seconds and was stopped. Another installation may be holding the Windows Installer service.' -f $InstallTimeoutSeconds)
+            return $false
+        }
+
+        $msiExitCode = $msiProcess.ExitCode
+        if ($msiExitCode -eq 0 -or $msiExitCode -eq 3010) {
+            return $true
+        }
+        Write-WarningMessage ('The PowerShell 7 MSI install failed (msiexec exit code {0}).' -f $msiExitCode)
+        return $false
+    }
+    finally {
+        Remove-Item -LiteralPath $downloadDirectory -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+<#
+.SYNOPSIS
     Finds or installs PowerShell 7, then relaunches the installer under pwsh in the same console.
 .DESCRIPTION
     The generated installer requires PowerShell 7+, but new machines ship with only Windows
@@ -928,8 +1207,9 @@ function Find-PowerShell7 {
         1. Find an existing pwsh.exe (Find-PowerShell7). Present -> relaunch immediately; this
            alone fixes the "opened the built-in Windows PowerShell out of habit" case.
         2. Missing -> install it, no consent prompt (issue #230): winget first (an exe,
-           version-agnostic, preinstalled on consumer Windows 11), falling back to the official
-           aka.ms/install-powershell.ps1 MSI script when winget is absent or fails. -WhatIf never
+           version-agnostic, preinstalled on consumer Windows 11); when winget is absent or fails,
+           the official MSI downloaded and run directly by Install-PowerShell7FromMsi, with
+           aka.ms/install-powershell.ps1 behind that as a last resort (issue #263). -WhatIf never
            installs anything and previews the plan instead.
         3. Relaunch the installer under pwsh with -NoProfile -ExecutionPolicy Bypass in the SAME
            console (output and prompts stay in the caller's window), forwarding the caller's
@@ -1052,15 +1332,25 @@ function Invoke-PowerShell7Bootstrap {
         }
 
         if (-not $pwshPath) {
-            Write-Info 'Falling back to the official PowerShell MSI installer (https://aka.ms/install-powershell.ps1)...'
-            try {
-                $msiInstallScript = Invoke-RestMethod -Uri 'https://aka.ms/install-powershell.ps1'
-                # Out-Host: the downloaded script's pipeline output must not leak into this
-                # function's return value (the tail dispatch exits with it).
-                & ([ScriptBlock]::Create($msiInstallScript)) -UseMSI -Quiet | Out-Host
-            }
-            catch {
-                Write-WarningMessage "The MSI fallback failed: $_"
+            # Direct MSI first, upstream script only if that fails (issue #263). Delegating
+            # straight to aka.ms/install-powershell.ps1 used to park the console for minutes with
+            # no output whatsoever - see Install-PowerShell7FromMsi's help for why - which on a
+            # stalled link is indistinguishable from the run having died. Doing the download here
+            # makes progress visible and both steps time-bounded.
+            Write-Info 'Falling back to the official PowerShell MSI installer...'
+            if (-not (Install-PowerShell7FromMsi)) {
+                Write-WarningMessage 'Falling back to the official installer script (https://aka.ms/install-powershell.ps1). It reports no download progress, so this step can run for several minutes with no output.'
+                try {
+                    # -TimeoutSec bounds the script download itself; the script's own MSI download
+                    # is the unbounded part this path accepts as a last resort.
+                    $msiInstallScript = Invoke-RestMethod -Uri 'https://aka.ms/install-powershell.ps1' -TimeoutSec 60
+                    # Out-Host: the downloaded script's pipeline output must not leak into this
+                    # function's return value (the tail dispatch exits with it).
+                    & ([ScriptBlock]::Create($msiInstallScript)) -UseMSI -Quiet | Out-Host
+                }
+                catch {
+                    Write-WarningMessage "The MSI fallback failed: $_"
+                }
             }
             $pwshPath = Find-PowerShell7
         }
@@ -1076,7 +1366,7 @@ function Invoke-PowerShell7Bootstrap {
     if (-not $relaunchPath) {
         Write-Info 'Downloading the installer for the PowerShell 7 relaunch...'
         try {
-            $installerContent = Invoke-RestMethod -Uri $InstallerUrl
+            $installerContent = Invoke-RestMethod -Uri $InstallerUrl -TimeoutSec 60
             # Unique per-run directory (issue #225 review): a fixed temp filename could be
             # pre-planted or swapped by another same-user process before the relaunch - which
             # matters extra here because the relaunched run may self-elevate from this very path -


### PR DESCRIPTION
Fixes #263

## The defect

Running the documented one-liner from Windows PowerShell 5.1 on a machine where the invoking
account has no winget, the console stops here and gives no further output:

```
Falling back to the official PowerShell MSI installer (https://aka.ms/install-powershell.ps1)...
VERBOSE: About to download package from
'https://github.com/PowerShell/PowerShell/releases/download/v7.6.4/PowerShell-7.6.4-win-x64.msi'
```

`Invoke-PowerShell7Bootstrap` delegated the whole install to
`aka.ms/install-powershell.ps1 -UseMSI -Quiet`. Reading that script explains the silence:

| Upstream line | What it does |
|---|---|
| 295-299 | sets `$ProgressPreference = 'SilentlyContinue'` on Windows PowerShell |
| 302 | `Invoke-WebRequest -Uri $url -OutFile $path` — **no read timeout** under 5.1 |
| 314 | logs "Performing quiet install" via `Write-Verbose` *without* `-Verbose`, so it never prints |
| 319 | `Start-Process msiexec ... -Wait` — unbounded |

So between "About to download package from…" and the next visible line there is a 110 MB
download plus a full MSI install with **zero** output. Measured on a real link that is 3.5
minutes of silence on a *healthy* run; on a stalled link it is indefinite, and nothing
distinguishes the two.

This is the gap #230 left open: the run no longer *asks* anything, but it could still park
forever with no way to tell slow from dead.

## The fix

Do both steps here, bounded and visible, keeping the upstream script as a last resort.

- **`Get-PowerShell7MsiInfo`** — resolves the release from the same `tools/metadata.json` the
  upstream script reads. Deliberately not the GitHub releases API: its unauthenticated
  60/hour budget is per source IP, which one office behind a NAT can exhaust for everyone.
  Architecture comes from `PROCESSOR_ARCHITEW6432`/`PROCESSOR_ARCHITECTURE` rather than
  `Get-ComputerInfo` (seconds to populate every property just to read one).
- **`Save-WebFileWithTimeout`** — `HttpWebRequest` whose `ReadWriteTimeout` bounds every
  individual read on the response stream, which is exactly the guarantee `Invoke-WebRequest`
  cannot give. Plus `-MaximumSeconds` for a link that trickles without ever formally
  stalling, periodic `X of 110.2 MB (N%)` lines, WinINET proxy credentials so an
  authenticating corporate proxy fails visibly instead of looking like another stall, and a
  short-read check so a truncated MSI is named here rather than as an opaque msiexec failure.
- **`Install-PowerShell7FromMsi`** — unique per-run temp directory (same swap-target reasoning
  as the relaunch path), `msiexec /i <msi> /quiet /norestart` under a bounded `WaitForExit`
  with `Kill()` on timeout, exit 3010 treated as success, cleanup in a `finally`.
- `Invoke-PowerShell7Bootstrap` tries the direct path first, and warns that the upstream
  script reports no progress before falling through to it.
- `-TimeoutSec` on both `Invoke-RestMethod` calls.

Everything in this file runs under Windows PowerShell 5.1, so it stays inside the file's
5.1-runtime contract; the header's helper list is updated to match.

## Testing

Full Pester 6.x suite: **337 passed, 0 failed, 3 skipped** (skip count unchanged).
`build/Build-WingetInstallScript.ps1 -Check` passes.

24 new unit tests cover release/architecture resolution, the msiexec argument shape, 3010
handling, the timeout `Kill()`, the download-fails and metadata-fails short-circuits, temp
directory cleanup, and the new fallback ordering.

Because unit tests mock the network, the download itself was also exercised against **real
Windows PowerShell 5.1** on Windows 11 (`powershell.exe`, engine 5.1.26100.8972), dot-sourcing
the generated installer:

```
=== overall MaximumSeconds abort (must stop, not hang) ===
  Downloading 110.2 MB...
  1.7 MB of 110.2 MB (2%)
  7.4 MB of 110.2 MB (7%)
The download failed: the download exceeded the 3-second limit after 9.2 MB
returned False after 4.2s

=== full real MSI download ===
  Downloading 110.2 MB...
  24.8 MB of 110.2 MB (23%)
  ... 26 progress lines ...
  108.5 MB of 110.2 MB (98%)
  Downloaded 110.2 MB in 212s.
returned True in 212.8s
bytes on disk: 115515392
is a valid MSI (OLE2 magic): True
```

DNS-failure and 404 paths return `$false` rather than throwing. Note the healthy full download
took **212 seconds** on this link — which is precisely how long the old code would have sat
there saying nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)