### PR TITLE
fix: Register staged App Installer before repairing winget (0x80073D06)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed winget bootstrap aborting outright when the machine carries a newer framework package than
+  the WinGet release pins (issue #265). `Repair-WinGetPackageManager -Latest -Force` deploys the
+  dependencies pinned to the release it installs, so on a machine whose
+  `Microsoft.WindowsAppRuntime` is already newer — routine wherever Teams / Phone Link / an MDM push
+  updates it independently — AppX rejects the downgrade with `0x80073D06`
+  (`ERROR_INSTALL_PACKAGE_DOWNGRADE`) and the cmdlet gives up *before* registering App Installer.
+  The run still recovers, but only on the last resort: a ~200 MB `aka.ms/getwinget` download, after
+  printing a wall of AppX deployment errors that reads like a broken machine. Both
+  `Repair-WinGetPackageManager` call sites (`Test-AndInstallWinget`,
+  `Initialize-WingetSourcesForUser`) now work through a cheapest-first ladder: the new private
+  `Register-WingetAppInstallerForUser` first registers the `Microsoft.DesktopAppInstaller` package
+  already staged on the machine for the current account (`Add-AppxPackage -RegisterByFamilyName`,
+  falling back to `-Register` against each candidate's `AppXManifest.xml`) — no download, no
+  dependency deployment, and the direct fix for the cross-user elevation case where the interactive
+  user has a working winget but the elevating admin account has no per-user registration and hence
+  no `winget.exe` alias. Only if that fails does the shared `Invoke-WingetPackageManagerRepair` run
+  the repair cmdlet unforced-then-forced, and a `0x80073D06` rejection (classified by
+  `Test-AppxDowngradeRejection` on the locale-independent hex HRESULT) short-circuits instead of
+  retrying with `-Force`, which cannot help and would burn a second multi-hundred-megabyte download.
+  `Initialize-WingetSourcesForUser` additionally names the dependency conflict in its remediation
+  advice. The `aka.ms/getwinget` download remains the unchanged last resort. This is the same
+  per-user-MSIX root cause as issue #263 below, one layer further into the run.
 - Fixed the PowerShell 7 MSI fallback blocking indefinitely with no output, which reads as a hang
   (issue #263). On a machine where the invoking account has no winget — the classic case being a
   secondary admin account, since winget is a per-user MSIX — `Invoke-PowerShell7Bootstrap` handed

--- a/STATUS.md
+++ b/STATUS.md
@@ -15,14 +15,15 @@ Windows-only cmdlets.
 ## Current State — 2026-08-11
 
 In review: **cheapest-first winget bootstrap ladder**
-([#265](https://github.com/J-MaFf/winget-app-setup/issues/265)) — a real cross-user elevation run on
-2026-08-11 got as far as installing and importing `Microsoft.WinGet.Client`, then failed to bootstrap
-winget at all: `Repair-WinGetPackageManager -Latest -Force` was rejected with `0x80073D06` because
+([#265](https://github.com/J-MaFf/winget-app-setup/issues/265)) — on a real cross-user elevation run
+on 2026-08-11, `Repair-WinGetPackageManager -Latest -Force` was rejected with `0x80073D06` because
 the machine's `Microsoft.WindowsAppRuntime.1.8` (8000.921.1539.0) is newer than the version the
-WinGet release pins (8000.616.304.0), so the cmdlet aborted before registering App Installer. The fix
-registers the already-staged `Microsoft.DesktopAppInstaller` package for the elevating account first
-(no download), only then falls back to the repair cmdlet — unforced before forced — and treats
-`0x80073D06` as non-retryable rather than escalating into a second large download.
+WinGet release pins (8000.616.304.0), so the cmdlet aborted before registering App Installer. The run
+did finish, but only after falling all the way through to the ~200 MB `aka.ms/getwinget` download and
+printing a wall of AppX errors that reads like a broken machine. The fix registers the already-staged
+`Microsoft.DesktopAppInstaller` package for the elevating account first (no download at all), only
+then falls back to the repair cmdlet — unforced before forced — and treats `0x80073D06` as
+non-retryable rather than escalating into a second large download.
 
 In review: **winget launch resilience while the app-execution alias is broken**
 ([#258](https://github.com/J-MaFf/winget-app-setup/issues/258)) — the 2026-07-27 scheduled E2E

--- a/STATUS.md
+++ b/STATUS.md
@@ -12,7 +12,17 @@ scripts target **Windows PowerShell / PowerShell 7 on Windows**; they cannot run
 Linux or macOS because they depend on `winget`, the `Microsoft.WinGet.Client` module, and
 Windows-only cmdlets.
 
-## Current State — 2026-08-10
+## Current State — 2026-08-11
+
+In review: **cheapest-first winget bootstrap ladder**
+([#265](https://github.com/J-MaFf/winget-app-setup/issues/265)) — a real cross-user elevation run on
+2026-08-11 got as far as installing and importing `Microsoft.WinGet.Client`, then failed to bootstrap
+winget at all: `Repair-WinGetPackageManager -Latest -Force` was rejected with `0x80073D06` because
+the machine's `Microsoft.WindowsAppRuntime.1.8` (8000.921.1539.0) is newer than the version the
+WinGet release pins (8000.616.304.0), so the cmdlet aborted before registering App Installer. The fix
+registers the already-staged `Microsoft.DesktopAppInstaller` package for the elevating account first
+(no download), only then falls back to the repair cmdlet — unforced before forced — and treats
+`0x80073D06` as non-retryable rather than escalating into a second large download.
 
 In review: **winget launch resilience while the app-execution alias is broken**
 ([#258](https://github.com/J-MaFf/winget-app-setup/issues/258)) — the 2026-07-27 scheduled E2E
@@ -184,6 +194,8 @@ Pester installs persist across runs there ([#161](https://github.com/J-MaFf/wing
 
 | Issue | Description | Status |
 |-------|-------------|--------|
+| [#265](https://github.com/J-MaFf/winget-app-setup/issues/265) | `Repair-WinGetPackageManager` aborts with `0x80073D06` when the machine has a newer `WindowsAppRuntime`, leaving winget unavailable | In review — PR [#266](https://github.com/J-MaFf/winget-app-setup/pull/266) |
+| [#263](https://github.com/J-MaFf/winget-app-setup/issues/263) | PowerShell 7 MSI fallback blocks forever with no output (looks like a hang) | Open |
 | [#258](https://github.com/J-MaFf/winget-app-setup/issues/258) | E2E install run failed: winget alias inaccessible through every launch retry (WAU/App Installer upgrade race) | In review — PR [#259](https://github.com/J-MaFf/winget-app-setup/pull/259) |
 | [#225](https://github.com/J-MaFf/winget-app-setup/issues/225) | Bootstrap PowerShell 7 from Windows PowerShell 5.1 instead of failing fast | In review — PR [#228](https://github.com/J-MaFf/winget-app-setup/pull/228) |
 | [#263](https://github.com/J-MaFf/winget-app-setup/issues/263) | PowerShell 7 MSI fallback blocks forever with no output (reads as a hang) | In review — PR [#264](https://github.com/J-MaFf/winget-app-setup/pull/264) |

--- a/WingetAppSetup/Private/WingetBootstrap.ps1
+++ b/WingetAppSetup/Private/WingetBootstrap.ps1
@@ -153,3 +153,183 @@ function Test-WingetSourceHealth {
         Healthy    = ($sourceIsListed -and $sourceIsFunctional)
     }
 }
+
+<#
+.SYNOPSIS
+    Tests whether an AppX/MSIX deployment error is the "a newer version is already installed"
+    downgrade rejection (0x80073D06).
+.DESCRIPTION
+    Repair-WinGetPackageManager deploys the framework dependencies pinned to the WinGet release it
+    installs (Microsoft.WindowsAppRuntime, VCLibs, UI.Xaml). When the machine already carries a
+    NEWER build of one of them - routine on managed fleets, where Teams / Phone Link / an MDM push
+    updates WindowsAppRuntime independently - AppX rejects the downgrade with 0x80073D06
+    (ERROR_INSTALL_PACKAGE_DOWNGRADE) and the cmdlet aborts BEFORE it ever registers App Installer,
+    so winget stays missing on a machine with nothing actually wrong with it (issue #265).
+
+    That failure is not retryable: -Force only makes the cmdlet more insistent about deploying the
+    older pinned build. Callers use this classifier to stop escalating and move to their next
+    fallback instead.
+
+    The '0x80073d06' token is the load-bearing part of the match - winget and AppX print the hex
+    HRESULT regardless of display language, so it survives locale and wording changes. The English
+    phrase is extra coverage only and, like the locale-dependency notes elsewhere in this module
+    (issues #177/#180), may stop matching if the wording changes.
+.PARAMETER Message
+    The exception or error text to classify.
+.RETURNS
+    [bool] True when the text carries the downgrade-rejection signature.
+#>
+function Test-AppxDowngradeRejection {
+    param (
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [AllowNull()]
+        [string]$Message
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Message)) {
+        return $false
+    }
+
+    return [bool]($Message -match '0x80073d06|higher version of this package is already installed')
+}
+
+<#
+.SYNOPSIS
+    Registers the App Installer (winget) MSIX already staged on this machine for the current account.
+.DESCRIPTION
+    The winget CLI is delivered by the Microsoft.DesktopAppInstaller MSIX package, which is
+    registered PER USER. When the installer runs elevated as a different admin account than the
+    logged-on user - the cross-user elevation this module already handles for sources and agreements
+    (issues #104/#150/#159) - that account has no registration and therefore no
+    %LOCALAPPDATA%\Microsoft\WindowsApps\winget.exe alias, even though the machine plainly has a
+    working winget for the interactive user.
+
+    Registering the payload that is ALREADY on disk is the cheapest fix for that case: no download,
+    no framework dependency deployment, and therefore none of the 0x80073D06 downgrade rejections
+    that abort Repair-WinGetPackageManager on a machine carrying a newer WindowsAppRuntime
+    (issue #265). That is why callers try this BEFORE the repair cmdlet, not after it.
+
+    Two registration forms are attempted, in order:
+      1. -RegisterByFamilyName, which needs only the package family name.
+      2. -Register against the AppXManifest.xml under each candidate's InstallLocation, which also
+         covers a package staged on the machine but never registered for this account.
+
+    Get-AppxPackage/Add-AppxPackage are used from pwsh here, as they already are elsewhere in this
+    module (Resolve-WingetExecutable, Test-AndInstallWinget). The Appx cmdlet known to be unreliable
+    under PowerShell 7 is the DISM-backed Add-AppxProvisionedPackage, which Invoke-AppxProvisioning
+    delegates to Windows PowerShell 5.1 for that reason; the per-user registration cmdlets used here
+    are not affected.
+.RETURNS
+    [bool] True when a registration call completed without error, otherwise False. Callers re-check
+    winget availability themselves - a successful registration is not proof the alias resolved.
+#>
+function Register-WingetAppInstallerForUser {
+    $familyName = 'Microsoft.DesktopAppInstaller_8wekyb3d8bbwe'
+
+    # -AllUsers requires elevation (which the installer already has) and is what surfaces a package
+    # staged on the machine but not registered for THIS account - precisely the case this helper
+    # exists for. Fall back to the current-user view if it is refused, so a non-elevated or
+    # policy-restricted run degrades instead of erroring out.
+    $candidates = @()
+    try {
+        $candidates = @(Get-AppxPackage -Name 'Microsoft.DesktopAppInstaller' -AllUsers -ErrorAction Stop)
+    }
+    catch {
+        try {
+            $candidates = @(Get-AppxPackage -Name 'Microsoft.DesktopAppInstaller' -ErrorAction Stop)
+        }
+        catch {
+            Write-WarningMessage "Could not enumerate the App Installer package: $_"
+            return $false
+        }
+    }
+
+    if ($candidates.Count -eq 0) {
+        Write-Info 'App Installer is not staged on this machine; there is nothing to register for this account.'
+        return $false
+    }
+
+    Write-Info 'Registering the App Installer package already on this machine for the current account...'
+    try {
+        Add-AppxPackage -RegisterByFamilyName -MainPackage $familyName -ErrorAction Stop
+        Write-Success 'App Installer registered for this account.'
+        return $true
+    }
+    catch {
+        Write-WarningMessage "Registering App Installer by family name failed: $_"
+    }
+
+    foreach ($candidate in $candidates) {
+        if (-not $candidate.InstallLocation) { continue }
+        $manifest = Join-Path $candidate.InstallLocation 'AppXManifest.xml'
+        if (-not (Test-Path $manifest)) { continue }
+
+        try {
+            # -Path is passed by name: -Register is a switch, so `-Register $manifest` would bind
+            # the manifest positionally and read as though it were the switch's argument.
+            Add-AppxPackage -Path $manifest -Register -DisableDevelopmentMode -ErrorAction Stop
+            Write-Success "App Installer registered for this account from $($candidate.InstallLocation)."
+            return $true
+        }
+        catch {
+            Write-WarningMessage "Registering App Installer from '$manifest' failed: $_"
+        }
+    }
+
+    return $false
+}
+
+<#
+.SYNOPSIS
+    Runs Repair-WinGetPackageManager, unforced first, and reports a 0x80073D06 rejection distinctly.
+.DESCRIPTION
+    Shared wrapper for the two places that bootstrap winget through the WinGet PowerShell module
+    (Test-AndInstallWinget and Initialize-WingetSourcesForUser), so the retry and error-classification
+    policy cannot diverge between them - the same reasoning that made Test-WingetSourceHealth shared
+    in issue #177.
+
+    The unforced attempt runs first so the cmdlet can skip framework dependencies that are already
+    present at an equal or newer version. -Force is still attempted afterwards, because it remains
+    the documented remedy for a genuinely broken or partial App Installer registration
+    (learn.microsoft.com/windows/package-manager/winget/troubleshooting) - but only when the unforced
+    pass failed for some OTHER reason. A 0x80073D06 downgrade rejection short-circuits immediately:
+    -Force cannot help, and retrying would burn a second multi-hundred-megabyte download before
+    failing the same way (issue #265).
+.RETURNS
+    [hashtable] @{ Available = <bool>; Succeeded = <bool>; DowngradeRejected = <bool>; Message = <string> }
+    Available is False when the Microsoft.WinGet.Client module is missing, in which case no repair
+    was attempted. Succeeded means a repair call completed without throwing - callers still verify
+    the outcome themselves (winget on PATH, or a source probe).
+#>
+function Invoke-WingetPackageManagerRepair {
+    if (-not (Get-Command Repair-WinGetPackageManager -ErrorAction SilentlyContinue)) {
+        return @{ Available = $false; Succeeded = $false; DowngradeRejected = $false; Message = '' }
+    }
+
+    $lastMessage = ''
+    foreach ($useForce in @($false, $true)) {
+        try {
+            if ($useForce) {
+                Repair-WinGetPackageManager -Latest -Force -ErrorAction Stop
+            }
+            else {
+                Repair-WinGetPackageManager -Latest -ErrorAction Stop
+            }
+
+            return @{ Available = $true; Succeeded = $true; DowngradeRejected = $false; Message = '' }
+        }
+        catch {
+            $lastMessage = "$_"
+
+            if (Test-AppxDowngradeRejection -Message $lastMessage) {
+                Write-WarningMessage 'Repair-WinGetPackageManager was rejected (0x80073D06): this machine already has a newer framework dependency than the WinGet release pins. That is a WinGet packaging conflict, not a fault on this machine.'
+                return @{ Available = $true; Succeeded = $false; DowngradeRejected = $true; Message = $lastMessage }
+            }
+
+            Write-WarningMessage "Repair-WinGetPackageManager failed: $lastMessage"
+        }
+    }
+
+    return @{ Available = $true; Succeeded = $false; DowngradeRejected = $false; Message = $lastMessage }
+}

--- a/WingetAppSetup/Private/WingetBootstrap.ps1
+++ b/WingetAppSetup/Private/WingetBootstrap.ps1
@@ -164,7 +164,8 @@ function Test-WingetSourceHealth {
     NEWER build of one of them - routine on managed fleets, where Teams / Phone Link / an MDM push
     updates WindowsAppRuntime independently - AppX rejects the downgrade with 0x80073D06
     (ERROR_INSTALL_PACKAGE_DOWNGRADE) and the cmdlet aborts BEFORE it ever registers App Installer,
-    so winget stays missing on a machine with nothing actually wrong with it (issue #265).
+    on a machine with nothing actually wrong with it. Callers still recover further down their
+    ladder, but only by paying for the heaviest rung they have (issue #265).
 
     That failure is not retryable: -Force only makes the cmdlet more insistent about deploying the
     older pinned build. Callers use this classifier to stop escalating and move to their next

--- a/WingetAppSetup/Public/WingetCore.ps1
+++ b/WingetAppSetup/Public/WingetCore.ps1
@@ -70,7 +70,9 @@ function Test-AndInstallWinget {
         return $true
     }
     else {
-        Write-WarningMessage 'Winget is not available. Trying to register the App Installer package already on this machine...'
+        # Register-WingetAppInstallerForUser narrates its own progress, so this only states the
+        # condition - saying "trying to register..." here too would duplicate its first line.
+        Write-WarningMessage 'Winget is not available.'
         if (Register-WingetAppInstallerForUser) {
             if (Get-Command winget -ErrorAction SilentlyContinue) {
                 Write-Success 'Winget is available after registering App Installer for this account.'

--- a/WingetAppSetup/Public/WingetCore.ps1
+++ b/WingetAppSetup/Public/WingetCore.ps1
@@ -46,7 +46,21 @@ function Test-AndInstallWingetModule {
 .SYNOPSIS
     Checks if winget is available and attempts to install it if not.
 .DESCRIPTION
-    This function verifies if winget is installed and available. If not, it attempts to install the Microsoft App Installer.
+    Verifies that the winget CLI is on PATH for the current account and, when it is not, works
+    through a cheapest-first bootstrap ladder (issue #265):
+
+      1. Register the Microsoft.DesktopAppInstaller package already staged on this machine for the
+         current account. No download and no framework dependency deployment, and it is the direct
+         fix for the cross-user elevation case where the machine has a working winget for the
+         interactive user but none for the elevating account.
+      2. Repair-WinGetPackageManager (unforced, then forced). Unlike a plain Add-AppxPackage this
+         registers App Installer even without an interactive logon session, where deployment is
+         otherwise blocked with 0x80073D19 (microsoft/winget-cli#3862, issue #159).
+      3. Download and register App Installer from aka.ms/getwinget.
+
+    Rung 1 comes first specifically because rung 2 can be blocked outright by a 0x80073D06
+    dependency downgrade rejection on a machine whose WindowsAppRuntime is newer than the WinGet
+    release pins - see Invoke-WingetPackageManagerRepair.
 .RETURNS
     [bool] True if winget is available or successfully installed, otherwise False.
 #>
@@ -56,23 +70,26 @@ function Test-AndInstallWinget {
         return $true
     }
     else {
-        # Prefer Repair-WinGetPackageManager when the WinGet PowerShell module is available: it
-        # registers the App Installer package for the current account even without an interactive
-        # logon session, where a plain Add-AppxPackage is blocked with 0x80073D19
-        # (microsoft/winget-cli#3862, issue #159).
+        Write-WarningMessage 'Winget is not available. Trying to register the App Installer package already on this machine...'
+        if (Register-WingetAppInstallerForUser) {
+            if (Get-Command winget -ErrorAction SilentlyContinue) {
+                Write-Success 'Winget is available after registering App Installer for this account.'
+                return $true
+            }
+            Write-WarningMessage 'App Installer was registered but winget is still unavailable.'
+        }
+
         if (Get-Command Repair-WinGetPackageManager -ErrorAction SilentlyContinue) {
-            Write-WarningMessage 'Winget is not available. Bootstrapping it via Repair-WinGetPackageManager...'
-            try {
-                Repair-WinGetPackageManager -Latest -Force -ErrorAction Stop
-                if (Get-Command winget -ErrorAction SilentlyContinue) {
-                    Write-Success 'Winget bootstrapped successfully via Repair-WinGetPackageManager.'
-                    return $true
-                }
-                Write-WarningMessage 'Repair-WinGetPackageManager completed but winget is still unavailable. Falling back to App Installer download...'
+            Write-WarningMessage 'Bootstrapping winget via Repair-WinGetPackageManager...'
+            [void](Invoke-WingetPackageManagerRepair)
+
+            # The repair result's own Succeeded flag is deliberately not trusted here: the cmdlet can
+            # report success without winget landing on PATH, so availability is re-checked directly.
+            if (Get-Command winget -ErrorAction SilentlyContinue) {
+                Write-Success 'Winget bootstrapped successfully via Repair-WinGetPackageManager.'
+                return $true
             }
-            catch {
-                Write-WarningMessage "Repair-WinGetPackageManager failed: $_. Falling back to App Installer download..."
-            }
+            Write-WarningMessage 'Winget is still unavailable after the repair attempt. Falling back to App Installer download...'
         }
 
         Write-WarningMessage 'Winget is not available. Attempting to install Microsoft App Installer...'
@@ -186,10 +203,15 @@ function Test-WingetSources {
 
     This function probes with `winget source update --name winget` (which forces the winget-source
     first-use bootstrap; agreements are accepted by the install commands, which pass
-    `--accept-source-agreements`). When the probe fails, it bootstraps winget for the account via
-    Repair-WinGetPackageManager — which registers the App Installer and Microsoft.Winget.Source
-    packages even without an interactive logon session (microsoft/winget-cli#6334) — and probes
-    again.
+    `--accept-source-agreements`). When the probe fails it re-probes after each of two bootstrap
+    attempts, cheapest first (issue #265):
+
+      1. Register the Microsoft.DesktopAppInstaller package already staged on this machine for this
+         account (Register-WingetAppInstallerForUser) — no download, no framework dependency
+         deployment.
+      2. Repair-WinGetPackageManager, which registers the App Installer and Microsoft.Winget.Source
+         packages even without an interactive logon session (microsoft/winget-cli#6334), but which
+         can be blocked outright by a 0x80073D06 dependency downgrade rejection — hence the ordering.
 .PARAMETER WhatIf
     When specified, only reports intended actions without executing.
 .RETURNS
@@ -237,18 +259,27 @@ function Initialize-WingetSourcesForUser {
         Write-WarningMessage "Winget source update failed with exit code: $($probe.ExitCode)"
     }
 
+    # Cheapest rung first: register the App Installer payload already staged on this machine for this
+    # account. On a cross-user elevation that alone can restore winget with no download at all, and
+    # it sidesteps the 0x80073D06 dependency rejection that can abort the repair cmdlet outright
+    # (issue #265).
+    if (Register-WingetAppInstallerForUser) {
+        $probe = Invoke-WingetSourceProbe
+        if ($probe.Succeeded) {
+            Write-Success 'Winget sources initialized for this account after registering App Installer.'
+            return $true
+        }
+    }
+
     # Bootstrap via the WinGet PowerShell module: unlike winget's own first-use bootstrap (and
     # unlike a plain Add-AppxPackage), Repair-WinGetPackageManager registers the App Installer and
     # Microsoft.Winget.Source packages for the current account even without an interactive logon
     # session (microsoft/winget-cli#6334).
+    $downgradeRejected = $false
     if (Get-Command Repair-WinGetPackageManager -ErrorAction SilentlyContinue) {
         Write-Info 'Bootstrapping winget for this account via Repair-WinGetPackageManager...'
-        try {
-            Repair-WinGetPackageManager -Latest -Force -ErrorAction Stop
-        }
-        catch {
-            Write-WarningMessage "Repair-WinGetPackageManager failed: $_"
-        }
+        $repair = Invoke-WingetPackageManagerRepair
+        $downgradeRejected = [bool]$repair.DowngradeRejected
 
         $probe = Invoke-WingetSourceProbe
         if ($probe.Succeeded) {
@@ -261,6 +292,9 @@ function Initialize-WingetSourcesForUser {
     }
 
     Write-WarningMessage "Winget sources could not be initialized for '$processUser'. Installations may fail with 0x80073D19."
+    if ($downgradeRejected) {
+        Write-WarningMessage 'Fix: update App Installer from the Microsoft Store on this machine (the WinGet release this module can deploy is older than a framework package already installed here), then re-run this script.'
+    }
     if ($isCrossUserElevation) {
         Write-WarningMessage "Fix: log on to Windows interactively as '$processUser' once (this registers winget for that account), or run 'winget source update' from any session running as '$processUser', then re-run this script."
     }

--- a/tests/WingetBootstrap.Tests.ps1
+++ b/tests/WingetBootstrap.Tests.ps1
@@ -258,3 +258,187 @@ Describe 'Invoke-WingetSourceProbe' {
         $script:probeRedirectPaths[0] | Should -Not -Be $script:probeRedirectPaths[2]
     }
 }
+
+Describe 'Test-AppxDowngradeRejection (0x80073D06 classifier, issue #265)' {
+    It 'Matches the hex HRESULT regardless of case' {
+        Test-AppxDowngradeRejection -Message 'Deployment failed with HRESULT: 0x80073D06, ...' | Should -Be $true
+        Test-AppxDowngradeRejection -Message 'deployment failed with hresult: 0x80073d06' | Should -Be $true
+    }
+
+    It 'Matches the English phrasing when the hex code is absent' {
+        Test-AppxDowngradeRejection -Message 'The package could not be installed because a higher version of this package is already installed.' |
+            Should -Be $true
+    }
+
+    It 'Matches the real Repair-WinGetPackageManager failure text' {
+        $message = 'Deployment failed with HRESULT: 0x80073D06, The package could not be installed because a higher version of this package is already installed.' + [Environment]::NewLine +
+        'Windows cannot install package Microsoft.WindowsAppRuntime.1.8_8000.616.304.0_x64__8wekyb3d8bbwe because it has version 8000.616.304.0. A higher version 8000.921.1539.0 of this package is already installed.'
+
+        Test-AppxDowngradeRejection -Message $message | Should -Be $true
+    }
+
+    It 'Does not match unrelated deployment failures' {
+        # 0x80073D19 is the blocked-logoff error this module already handles separately; it must
+        # keep escalating through the ladder rather than being short-circuited as non-retryable.
+        Test-AppxDowngradeRejection -Message 'Deployment failed with HRESULT: 0x80073D19' | Should -Be $false
+        Test-AppxDowngradeRejection -Message 'Network error' | Should -Be $false
+    }
+
+    It 'Treats empty and null text as not a downgrade rejection' {
+        Test-AppxDowngradeRejection -Message '' | Should -Be $false
+        Test-AppxDowngradeRejection -Message $null | Should -Be $false
+    }
+}
+
+Describe 'Register-WingetAppInstallerForUser (issue #265)' {
+    BeforeEach {
+        Mock Write-Host { }
+        Mock Write-Info { }
+        Mock Write-Success { }
+        Mock Write-WarningMessage { }
+    }
+
+    It 'Registers the staged package by family name and reports success' {
+        Mock Get-AppxPackage { [pscustomobject]@{ InstallLocation = 'C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_1.26.0.0_x64__8wekyb3d8bbwe' } }
+        Mock Add-AppxPackage { }
+
+        Register-WingetAppInstallerForUser | Should -Be $true
+
+        Should -Invoke Add-AppxPackage -Times 1 -Exactly -ParameterFilter {
+            $RegisterByFamilyName -and $MainPackage -eq 'Microsoft.DesktopAppInstaller_8wekyb3d8bbwe'
+        }
+    }
+
+    It 'Enumerates packages staged for other accounts, not just this one' {
+        # -AllUsers is what surfaces a package staged on the machine but never registered for the
+        # elevating account - the whole case this helper exists for.
+        Mock Get-AppxPackage { [pscustomobject]@{ InstallLocation = 'C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_1.26.0.0_x64__8wekyb3d8bbwe' } }
+        Mock Add-AppxPackage { }
+
+        [void](Register-WingetAppInstallerForUser)
+
+        Should -Invoke Get-AppxPackage -Times 1 -Exactly -ParameterFilter { $AllUsers }
+    }
+
+    It 'Falls back to registering from the package manifest when the family-name form fails' {
+        $installLocation = 'C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_1.26.0.0_x64__8wekyb3d8bbwe'
+        Mock Get-AppxPackage { [pscustomobject]@{ InstallLocation = $installLocation } }
+        Mock Test-Path { $true }
+        Mock Add-AppxPackage { throw 'family name registration failed' } -ParameterFilter { $RegisterByFamilyName }
+        Mock Add-AppxPackage { } -ParameterFilter { $Register }
+
+        Register-WingetAppInstallerForUser | Should -Be $true
+
+        Should -Invoke Add-AppxPackage -Times 1 -Exactly -ParameterFilter {
+            $Register -and $Path -eq (Join-Path $installLocation 'AppXManifest.xml')
+        }
+    }
+
+    It 'Returns false without registering anything when App Installer is not staged' {
+        Mock Get-AppxPackage { @() }
+        Mock Add-AppxPackage { throw 'nothing to register' }
+
+        Register-WingetAppInstallerForUser | Should -Be $false
+
+        Should -Invoke Add-AppxPackage -Times 0 -Exactly
+    }
+
+    It 'Returns false when every registration form fails' {
+        Mock Get-AppxPackage { [pscustomobject]@{ InstallLocation = 'C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_1.26.0.0_x64__8wekyb3d8bbwe' } }
+        Mock Test-Path { $true }
+        Mock Add-AppxPackage { throw 'registration failed' }
+
+        Register-WingetAppInstallerForUser | Should -Be $false
+    }
+
+    It 'Falls back to the current-user view when the all-users enumeration is refused' {
+        Mock Get-AppxPackage { throw 'access denied' } -ParameterFilter { $AllUsers }
+        Mock Get-AppxPackage { [pscustomobject]@{ InstallLocation = 'C:\Program Files\WindowsApps\Microsoft.DesktopAppInstaller_1.26.0.0_x64__8wekyb3d8bbwe' } } -ParameterFilter { -not $AllUsers }
+        Mock Add-AppxPackage { }
+
+        Register-WingetAppInstallerForUser | Should -Be $true
+    }
+
+    It 'Returns false when the package cannot be enumerated at all' {
+        Mock Get-AppxPackage { throw 'Appx provider unavailable' }
+        Mock Add-AppxPackage { throw 'nothing to register' }
+
+        Register-WingetAppInstallerForUser | Should -Be $false
+
+        Should -Invoke Add-AppxPackage -Times 0 -Exactly
+    }
+}
+
+Describe 'Invoke-WingetPackageManagerRepair (issue #265)' {
+    BeforeAll {
+        # Stub so the cmdlet can be mocked on machines without the Microsoft.WinGet.Client module.
+        function Repair-WinGetPackageManager { param([switch]$Latest, [switch]$Force) }
+    }
+
+    BeforeEach {
+        Mock Write-Host { }
+        Mock Write-WarningMessage { }
+        # Safety net (#181): never let the real cmdlet run during unit tests.
+        Mock Repair-WinGetPackageManager { }
+        Mock Get-Command { [pscustomobject]@{ Name = 'Repair-WinGetPackageManager' } } -ParameterFilter { $Name -eq 'Repair-WinGetPackageManager' }
+    }
+
+    It 'Reports the cmdlet as unavailable without attempting a repair' {
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'Repair-WinGetPackageManager' }
+
+        $result = Invoke-WingetPackageManagerRepair
+
+        $result.Available | Should -Be $false
+        $result.Succeeded | Should -Be $false
+        Should -Invoke Repair-WinGetPackageManager -Times 0 -Exactly
+    }
+
+    It 'Tries the unforced repair first and stops there when it succeeds' {
+        $result = Invoke-WingetPackageManagerRepair
+
+        $result.Succeeded | Should -Be $true
+        $result.DowngradeRejected | Should -Be $false
+        Should -Invoke Repair-WinGetPackageManager -Times 1 -Exactly -ParameterFilter { $Latest -and -not $Force }
+    }
+
+    It 'Escalates to -Force when the unforced repair fails for an unrelated reason' {
+        $script:repairAttempts = 0
+        Mock Repair-WinGetPackageManager {
+            $script:repairAttempts++
+            if ($script:repairAttempts -eq 1) { throw 'something else went wrong' }
+        }
+
+        $result = Invoke-WingetPackageManagerRepair
+
+        $result.Succeeded | Should -Be $true
+        Should -Invoke Repair-WinGetPackageManager -Times 2 -Exactly
+        Should -Invoke Repair-WinGetPackageManager -Times 1 -Exactly -ParameterFilter { $Force }
+    }
+
+    It 'Does not escalate to -Force on a 0x80073D06 downgrade rejection' {
+        Mock Repair-WinGetPackageManager {
+            throw 'Deployment failed with HRESULT: 0x80073D06, The package could not be installed because a higher version of this package is already installed.'
+        }
+
+        $result = Invoke-WingetPackageManagerRepair
+
+        $result.Available | Should -Be $true
+        $result.Succeeded | Should -Be $false
+        $result.DowngradeRejected | Should -Be $true
+        $result.Message | Should -Match '0x80073D06'
+        Should -Invoke Repair-WinGetPackageManager -Times 1 -Exactly
+        Should -Invoke Write-WarningMessage -Times 1 -ParameterFilter { $Message -match 'newer framework dependency' }
+    }
+
+    It 'Reports a plain failure when both the unforced and forced repairs fail' {
+        Mock Repair-WinGetPackageManager { throw 'network error' }
+
+        $result = Invoke-WingetPackageManagerRepair
+
+        $result.Available | Should -Be $true
+        $result.Succeeded | Should -Be $false
+        $result.DowngradeRejected | Should -Be $false
+        $result.Message | Should -Match 'network error'
+        Should -Invoke Repair-WinGetPackageManager -Times 2 -Exactly
+    }
+}

--- a/tests/WingetCore.Tests.ps1
+++ b/tests/WingetCore.Tests.ps1
@@ -86,6 +86,11 @@ Describe 'Test-AndInstallWinget' {
         # Default: the repair cmdlet appears absent, so tests exercise the plain
         # aka.ms/getwinget fallback unless a test overrides this lookup.
         Mock Get-Command { $null } -ParameterFilter { $Name -eq 'Repair-WinGetPackageManager' }
+        # Default: nothing to register for this account, so the ladder's first rung (issue #265)
+        # is a no-op and the pre-existing repair/download behavior below is what gets exercised.
+        # Mocked as a seam rather than mocking Get-AppxPackage/Add-AppxPackage directly, so an
+        # accidental miss can never reach the real AppX deployment cmdlets.
+        Mock Register-WingetAppInstallerForUser { $false }
     }
 
     Context 'When winget is available' {
@@ -184,8 +189,81 @@ Describe 'Test-AndInstallWinget' {
 
             $result = Test-AndInstallWinget
             $result | Should -Be $true
-            Should -Invoke Repair-WinGetPackageManager -Times 1 -Exactly
+            # Unforced then forced (issue #265): a non-downgrade failure still escalates to -Force,
+            # which remains the documented remedy for a broken App Installer registration.
+            Should -Invoke Repair-WinGetPackageManager -Times 2 -Exactly
+            Should -Invoke Repair-WinGetPackageManager -Times 1 -Exactly -ParameterFilter { -not $Force }
+            Should -Invoke Repair-WinGetPackageManager -Times 1 -Exactly -ParameterFilter { $Force }
             Should -Invoke Invoke-WebRequest -Times 1
+            Should -Invoke Add-AppxPackage -Times 1
+        }
+    }
+
+    Context 'When App Installer is already staged on the machine (issue #265)' {
+        It 'Registers it for this account and returns true without repairing or downloading' {
+            $script:registered = $false
+            Mock Get-Command {
+                if ($script:registered) { return $true }
+                return $null
+            } -ParameterFilter { $Name -eq 'winget' }
+            Mock Get-Command { return $true } -ParameterFilter { $Name -eq 'Repair-WinGetPackageManager' }
+            Mock Register-WingetAppInstallerForUser { $script:registered = $true; return $true }
+            Mock Invoke-WebRequest { }
+            Mock Add-AppxPackage { }
+
+            $result = Test-AndInstallWinget
+
+            $result | Should -Be $true
+            Should -Invoke Register-WingetAppInstallerForUser -Times 1 -Exactly
+            Should -Invoke Repair-WinGetPackageManager -Times 0 -Exactly
+            Should -Invoke Invoke-WebRequest -Times 0
+            Should -Invoke Add-AppxPackage -Times 0
+        }
+
+        It 'Falls through to the repair cmdlet when registration does not make winget resolve' {
+            # Registration can report success without the app-execution alias landing on PATH, so
+            # availability is re-checked rather than inferred from the registration result.
+            $script:wingetAvailable = $false
+            Mock Get-Command {
+                if ($script:wingetAvailable) { return $true }
+                return $null
+            } -ParameterFilter { $Name -eq 'winget' }
+            Mock Get-Command { return $true } -ParameterFilter { $Name -eq 'Repair-WinGetPackageManager' }
+            Mock Register-WingetAppInstallerForUser { $true }
+            Mock Repair-WinGetPackageManager { $script:wingetAvailable = $true }
+            Mock Invoke-WebRequest { }
+            Mock Add-AppxPackage { }
+
+            $result = Test-AndInstallWinget
+
+            $result | Should -Be $true
+            Should -Invoke Register-WingetAppInstallerForUser -Times 1 -Exactly
+            Should -Invoke Repair-WinGetPackageManager -Times 1 -Exactly
+            Should -Invoke Invoke-WebRequest -Times 0
+        }
+    }
+
+    Context 'When the repair cmdlet is blocked by a dependency downgrade (issue #265)' {
+        It 'Does not retry with -Force and falls through to the App Installer download' {
+            $script:appInstallerRegistered = $false
+            Mock Get-Command {
+                if ($script:appInstallerRegistered) { return $true }
+                return $null
+            } -ParameterFilter { $Name -eq 'winget' }
+            Mock Get-Command { return $true } -ParameterFilter { $Name -eq 'Repair-WinGetPackageManager' }
+            Mock Repair-WinGetPackageManager {
+                throw 'Deployment failed with HRESULT: 0x80073D06, The package could not be installed because a higher version of this package is already installed.'
+            }
+            Mock Invoke-WebRequest { }
+            Mock Add-AppxPackage { $script:appInstallerRegistered = $true }
+            Mock Remove-Item { }
+
+            $result = Test-AndInstallWinget
+
+            $result | Should -Be $true
+            # One attempt only: -Force cannot fix a rejection caused by a NEWER dependency already
+            # being present, and retrying would burn a second multi-hundred-megabyte download.
+            Should -Invoke Repair-WinGetPackageManager -Times 1 -Exactly
             Should -Invoke Add-AppxPackage -Times 1
         }
     }
@@ -929,6 +1007,9 @@ Describe 'Initialize-WingetSourcesForUser (cross-user bootstrap, issue #159)' {
         Mock Get-InteractiveSessionUserName { 'CONTOSO\admin-jmaffiola' }
         # Repair-WinGetPackageManager resolves as available unless a test overrides this.
         Mock Get-Command { [pscustomobject]@{ Name = 'Repair-WinGetPackageManager' } } -ParameterFilter { $Name -eq 'Repair-WinGetPackageManager' }
+        # Default: nothing staged to register for this account, so the ladder's first rung
+        # (issue #265) is a no-op and the repair path below is what gets exercised.
+        Mock Register-WingetAppInstallerForUser { $false }
     }
 
     It 'Reports the dry run without probing' {
@@ -987,6 +1068,38 @@ Describe 'Initialize-WingetSourcesForUser (cross-user bootstrap, issue #159)' {
         $result | Should -Be $false
         Should -Invoke Repair-WinGetPackageManager -Times 0 -Exactly
         Should -Invoke Invoke-WingetSourceProbe -Times 1 -Exactly
+    }
+
+    It 'Registers the staged App Installer before repairing and succeeds when the re-probe passes (issue #265)' {
+        $script:probeCallCount = 0
+        Mock Invoke-WingetSourceProbe {
+            $script:probeCallCount++
+            if ($script:probeCallCount -eq 1) {
+                return @{ Succeeded = $false; ExitCode = -2147009255; TimedOut = $false }
+            }
+            return @{ Succeeded = $true; ExitCode = 0; TimedOut = $false }
+        }
+        Mock Register-WingetAppInstallerForUser { $true }
+
+        $result = Initialize-WingetSourcesForUser
+
+        $result | Should -Be $true
+        Should -Invoke Register-WingetAppInstallerForUser -Times 1 -Exactly
+        Should -Invoke Repair-WinGetPackageManager -Times 0 -Exactly
+        Should -Invoke Invoke-WingetSourceProbe -Times 2 -Exactly
+    }
+
+    It 'Names the dependency conflict in its remediation advice when the repair is downgrade-rejected (issue #265)' {
+        Mock Invoke-WingetSourceProbe { @{ Succeeded = $false; ExitCode = -2147009255; TimedOut = $false } }
+        Mock Repair-WinGetPackageManager {
+            throw 'Deployment failed with HRESULT: 0x80073D06, The package could not be installed because a higher version of this package is already installed.'
+        }
+
+        $result = Initialize-WingetSourcesForUser
+
+        $result | Should -Be $false
+        Should -Invoke Repair-WinGetPackageManager -Times 1 -Exactly
+        Should -Invoke Write-WarningMessage -Times 1 -ParameterFilter { $Message -match 'update App Installer from the Microsoft Store' }
     }
 
     It 'Warns about cross-user elevation when the process account differs from the session owner' {

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -58,12 +58,12 @@ param (
 # This script is assembled from the WingetAppSetup module by build/Build-WingetInstallScript.ps1.
 # Edit the function source under WingetAppSetup/Public and WingetAppSetup/Private, then re-run the
 # build to regenerate this file. See readme.md ("Project layout") for details.
-# Build id: 1.0.0+bc94bb48 (module version + SHA256 fragment of the function content; issue #189).
+# Build id: 1.0.0+8d8f7de6 (module version + SHA256 fragment of the function content; issue #189).
 # ------------------------------------------------------------------------------------------------
 
 # Content-derived build identity, logged at startup so a transcript from a remote machine
 # identifies exactly which installer build produced it (issue #189).
-$script:InstallerBuildId = '1.0.0+bc94bb48'
+$script:InstallerBuildId = '1.0.0+8d8f7de6'
 
 # ------------------------------------------------Functions------------------------------------------------
 
@@ -1756,7 +1756,8 @@ function Test-WingetSourceHealth {
     NEWER build of one of them - routine on managed fleets, where Teams / Phone Link / an MDM push
     updates WindowsAppRuntime independently - AppX rejects the downgrade with 0x80073D06
     (ERROR_INSTALL_PACKAGE_DOWNGRADE) and the cmdlet aborts BEFORE it ever registers App Installer,
-    so winget stays missing on a machine with nothing actually wrong with it (issue #265).
+    on a machine with nothing actually wrong with it. Callers still recover further down their
+    ladder, but only by paying for the heaviest rung they have (issue #265).
 
     That failure is not retryable: -Force only makes the cmdlet more insistent about deploying the
     older pinned build. Callers use this classifier to stop escalating and move to their next
@@ -3523,7 +3524,9 @@ function Test-AndInstallWinget {
         return $true
     }
     else {
-        Write-WarningMessage 'Winget is not available. Trying to register the App Installer package already on this machine...'
+        # Register-WingetAppInstallerForUser narrates its own progress, so this only states the
+        # condition - saying "trying to register..." here too would duplicate its first line.
+        Write-WarningMessage 'Winget is not available.'
         if (Register-WingetAppInstallerForUser) {
             if (Get-Command winget -ErrorAction SilentlyContinue) {
                 Write-Success 'Winget is available after registering App Installer for this account.'

--- a/winget-app-install.ps1
+++ b/winget-app-install.ps1
@@ -58,12 +58,12 @@ param (
 # This script is assembled from the WingetAppSetup module by build/Build-WingetInstallScript.ps1.
 # Edit the function source under WingetAppSetup/Public and WingetAppSetup/Private, then re-run the
 # build to regenerate this file. See readme.md ("Project layout") for details.
-# Build id: 1.0.0+45fed6f6 (module version + SHA256 fragment of the function content; issue #189).
+# Build id: 1.0.0+bc94bb48 (module version + SHA256 fragment of the function content; issue #189).
 # ------------------------------------------------------------------------------------------------
 
 # Content-derived build identity, logged at startup so a transcript from a remote machine
 # identifies exactly which installer build produced it (issue #189).
-$script:InstallerBuildId = '1.0.0+45fed6f6'
+$script:InstallerBuildId = '1.0.0+bc94bb48'
 
 # ------------------------------------------------Functions------------------------------------------------
 
@@ -1746,6 +1746,186 @@ function Test-WingetSourceHealth {
     }
 }
 
+<#
+.SYNOPSIS
+    Tests whether an AppX/MSIX deployment error is the "a newer version is already installed"
+    downgrade rejection (0x80073D06).
+.DESCRIPTION
+    Repair-WinGetPackageManager deploys the framework dependencies pinned to the WinGet release it
+    installs (Microsoft.WindowsAppRuntime, VCLibs, UI.Xaml). When the machine already carries a
+    NEWER build of one of them - routine on managed fleets, where Teams / Phone Link / an MDM push
+    updates WindowsAppRuntime independently - AppX rejects the downgrade with 0x80073D06
+    (ERROR_INSTALL_PACKAGE_DOWNGRADE) and the cmdlet aborts BEFORE it ever registers App Installer,
+    so winget stays missing on a machine with nothing actually wrong with it (issue #265).
+
+    That failure is not retryable: -Force only makes the cmdlet more insistent about deploying the
+    older pinned build. Callers use this classifier to stop escalating and move to their next
+    fallback instead.
+
+    The '0x80073d06' token is the load-bearing part of the match - winget and AppX print the hex
+    HRESULT regardless of display language, so it survives locale and wording changes. The English
+    phrase is extra coverage only and, like the locale-dependency notes elsewhere in this module
+    (issues #177/#180), may stop matching if the wording changes.
+.PARAMETER Message
+    The exception or error text to classify.
+.RETURNS
+    [bool] True when the text carries the downgrade-rejection signature.
+#>
+function Test-AppxDowngradeRejection {
+    param (
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [AllowNull()]
+        [string]$Message
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Message)) {
+        return $false
+    }
+
+    return [bool]($Message -match '0x80073d06|higher version of this package is already installed')
+}
+
+<#
+.SYNOPSIS
+    Registers the App Installer (winget) MSIX already staged on this machine for the current account.
+.DESCRIPTION
+    The winget CLI is delivered by the Microsoft.DesktopAppInstaller MSIX package, which is
+    registered PER USER. When the installer runs elevated as a different admin account than the
+    logged-on user - the cross-user elevation this module already handles for sources and agreements
+    (issues #104/#150/#159) - that account has no registration and therefore no
+    %LOCALAPPDATA%\Microsoft\WindowsApps\winget.exe alias, even though the machine plainly has a
+    working winget for the interactive user.
+
+    Registering the payload that is ALREADY on disk is the cheapest fix for that case: no download,
+    no framework dependency deployment, and therefore none of the 0x80073D06 downgrade rejections
+    that abort Repair-WinGetPackageManager on a machine carrying a newer WindowsAppRuntime
+    (issue #265). That is why callers try this BEFORE the repair cmdlet, not after it.
+
+    Two registration forms are attempted, in order:
+      1. -RegisterByFamilyName, which needs only the package family name.
+      2. -Register against the AppXManifest.xml under each candidate's InstallLocation, which also
+         covers a package staged on the machine but never registered for this account.
+
+    Get-AppxPackage/Add-AppxPackage are used from pwsh here, as they already are elsewhere in this
+    module (Resolve-WingetExecutable, Test-AndInstallWinget). The Appx cmdlet known to be unreliable
+    under PowerShell 7 is the DISM-backed Add-AppxProvisionedPackage, which Invoke-AppxProvisioning
+    delegates to Windows PowerShell 5.1 for that reason; the per-user registration cmdlets used here
+    are not affected.
+.RETURNS
+    [bool] True when a registration call completed without error, otherwise False. Callers re-check
+    winget availability themselves - a successful registration is not proof the alias resolved.
+#>
+function Register-WingetAppInstallerForUser {
+    $familyName = 'Microsoft.DesktopAppInstaller_8wekyb3d8bbwe'
+
+    # -AllUsers requires elevation (which the installer already has) and is what surfaces a package
+    # staged on the machine but not registered for THIS account - precisely the case this helper
+    # exists for. Fall back to the current-user view if it is refused, so a non-elevated or
+    # policy-restricted run degrades instead of erroring out.
+    $candidates = @()
+    try {
+        $candidates = @(Get-AppxPackage -Name 'Microsoft.DesktopAppInstaller' -AllUsers -ErrorAction Stop)
+    }
+    catch {
+        try {
+            $candidates = @(Get-AppxPackage -Name 'Microsoft.DesktopAppInstaller' -ErrorAction Stop)
+        }
+        catch {
+            Write-WarningMessage "Could not enumerate the App Installer package: $_"
+            return $false
+        }
+    }
+
+    if ($candidates.Count -eq 0) {
+        Write-Info 'App Installer is not staged on this machine; there is nothing to register for this account.'
+        return $false
+    }
+
+    Write-Info 'Registering the App Installer package already on this machine for the current account...'
+    try {
+        Add-AppxPackage -RegisterByFamilyName -MainPackage $familyName -ErrorAction Stop
+        Write-Success 'App Installer registered for this account.'
+        return $true
+    }
+    catch {
+        Write-WarningMessage "Registering App Installer by family name failed: $_"
+    }
+
+    foreach ($candidate in $candidates) {
+        if (-not $candidate.InstallLocation) { continue }
+        $manifest = Join-Path $candidate.InstallLocation 'AppXManifest.xml'
+        if (-not (Test-Path $manifest)) { continue }
+
+        try {
+            # -Path is passed by name: -Register is a switch, so `-Register $manifest` would bind
+            # the manifest positionally and read as though it were the switch's argument.
+            Add-AppxPackage -Path $manifest -Register -DisableDevelopmentMode -ErrorAction Stop
+            Write-Success "App Installer registered for this account from $($candidate.InstallLocation)."
+            return $true
+        }
+        catch {
+            Write-WarningMessage "Registering App Installer from '$manifest' failed: $_"
+        }
+    }
+
+    return $false
+}
+
+<#
+.SYNOPSIS
+    Runs Repair-WinGetPackageManager, unforced first, and reports a 0x80073D06 rejection distinctly.
+.DESCRIPTION
+    Shared wrapper for the two places that bootstrap winget through the WinGet PowerShell module
+    (Test-AndInstallWinget and Initialize-WingetSourcesForUser), so the retry and error-classification
+    policy cannot diverge between them - the same reasoning that made Test-WingetSourceHealth shared
+    in issue #177.
+
+    The unforced attempt runs first so the cmdlet can skip framework dependencies that are already
+    present at an equal or newer version. -Force is still attempted afterwards, because it remains
+    the documented remedy for a genuinely broken or partial App Installer registration
+    (learn.microsoft.com/windows/package-manager/winget/troubleshooting) - but only when the unforced
+    pass failed for some OTHER reason. A 0x80073D06 downgrade rejection short-circuits immediately:
+    -Force cannot help, and retrying would burn a second multi-hundred-megabyte download before
+    failing the same way (issue #265).
+.RETURNS
+    [hashtable] @{ Available = <bool>; Succeeded = <bool>; DowngradeRejected = <bool>; Message = <string> }
+    Available is False when the Microsoft.WinGet.Client module is missing, in which case no repair
+    was attempted. Succeeded means a repair call completed without throwing - callers still verify
+    the outcome themselves (winget on PATH, or a source probe).
+#>
+function Invoke-WingetPackageManagerRepair {
+    if (-not (Get-Command Repair-WinGetPackageManager -ErrorAction SilentlyContinue)) {
+        return @{ Available = $false; Succeeded = $false; DowngradeRejected = $false; Message = '' }
+    }
+
+    $lastMessage = ''
+    foreach ($useForce in @($false, $true)) {
+        try {
+            if ($useForce) {
+                Repair-WinGetPackageManager -Latest -Force -ErrorAction Stop
+            }
+            else {
+                Repair-WinGetPackageManager -Latest -ErrorAction Stop
+            }
+
+            return @{ Available = $true; Succeeded = $true; DowngradeRejected = $false; Message = '' }
+        }
+        catch {
+            $lastMessage = "$_"
+
+            if (Test-AppxDowngradeRejection -Message $lastMessage) {
+                Write-WarningMessage 'Repair-WinGetPackageManager was rejected (0x80073D06): this machine already has a newer framework dependency than the WinGet release pins. That is a WinGet packaging conflict, not a fault on this machine.'
+                return @{ Available = $true; Succeeded = $false; DowngradeRejected = $true; Message = $lastMessage }
+            }
+
+            Write-WarningMessage "Repair-WinGetPackageManager failed: $lastMessage"
+        }
+    }
+
+    return @{ Available = $true; Succeeded = $false; DowngradeRejected = $false; Message = $lastMessage }
+}
+
 # --- WingetLaunchResilience ---
 # Winget launch resilience helpers (issue #258). Start-Process can fail to launch winget.exe at
 # all when the per-user app-execution alias under %LOCALAPPDATA%\Microsoft\WindowsApps is broken
@@ -3319,7 +3499,21 @@ function Test-AndInstallWingetModule {
 .SYNOPSIS
     Checks if winget is available and attempts to install it if not.
 .DESCRIPTION
-    This function verifies if winget is installed and available. If not, it attempts to install the Microsoft App Installer.
+    Verifies that the winget CLI is on PATH for the current account and, when it is not, works
+    through a cheapest-first bootstrap ladder (issue #265):
+
+      1. Register the Microsoft.DesktopAppInstaller package already staged on this machine for the
+         current account. No download and no framework dependency deployment, and it is the direct
+         fix for the cross-user elevation case where the machine has a working winget for the
+         interactive user but none for the elevating account.
+      2. Repair-WinGetPackageManager (unforced, then forced). Unlike a plain Add-AppxPackage this
+         registers App Installer even without an interactive logon session, where deployment is
+         otherwise blocked with 0x80073D19 (microsoft/winget-cli#3862, issue #159).
+      3. Download and register App Installer from aka.ms/getwinget.
+
+    Rung 1 comes first specifically because rung 2 can be blocked outright by a 0x80073D06
+    dependency downgrade rejection on a machine whose WindowsAppRuntime is newer than the WinGet
+    release pins - see Invoke-WingetPackageManagerRepair.
 .RETURNS
     [bool] True if winget is available or successfully installed, otherwise False.
 #>
@@ -3329,23 +3523,26 @@ function Test-AndInstallWinget {
         return $true
     }
     else {
-        # Prefer Repair-WinGetPackageManager when the WinGet PowerShell module is available: it
-        # registers the App Installer package for the current account even without an interactive
-        # logon session, where a plain Add-AppxPackage is blocked with 0x80073D19
-        # (microsoft/winget-cli#3862, issue #159).
+        Write-WarningMessage 'Winget is not available. Trying to register the App Installer package already on this machine...'
+        if (Register-WingetAppInstallerForUser) {
+            if (Get-Command winget -ErrorAction SilentlyContinue) {
+                Write-Success 'Winget is available after registering App Installer for this account.'
+                return $true
+            }
+            Write-WarningMessage 'App Installer was registered but winget is still unavailable.'
+        }
+
         if (Get-Command Repair-WinGetPackageManager -ErrorAction SilentlyContinue) {
-            Write-WarningMessage 'Winget is not available. Bootstrapping it via Repair-WinGetPackageManager...'
-            try {
-                Repair-WinGetPackageManager -Latest -Force -ErrorAction Stop
-                if (Get-Command winget -ErrorAction SilentlyContinue) {
-                    Write-Success 'Winget bootstrapped successfully via Repair-WinGetPackageManager.'
-                    return $true
-                }
-                Write-WarningMessage 'Repair-WinGetPackageManager completed but winget is still unavailable. Falling back to App Installer download...'
+            Write-WarningMessage 'Bootstrapping winget via Repair-WinGetPackageManager...'
+            [void](Invoke-WingetPackageManagerRepair)
+
+            # The repair result's own Succeeded flag is deliberately not trusted here: the cmdlet can
+            # report success without winget landing on PATH, so availability is re-checked directly.
+            if (Get-Command winget -ErrorAction SilentlyContinue) {
+                Write-Success 'Winget bootstrapped successfully via Repair-WinGetPackageManager.'
+                return $true
             }
-            catch {
-                Write-WarningMessage "Repair-WinGetPackageManager failed: $_. Falling back to App Installer download..."
-            }
+            Write-WarningMessage 'Winget is still unavailable after the repair attempt. Falling back to App Installer download...'
         }
 
         Write-WarningMessage 'Winget is not available. Attempting to install Microsoft App Installer...'
@@ -3459,10 +3656,15 @@ function Test-WingetSources {
 
     This function probes with `winget source update --name winget` (which forces the winget-source
     first-use bootstrap; agreements are accepted by the install commands, which pass
-    `--accept-source-agreements`). When the probe fails, it bootstraps winget for the account via
-    Repair-WinGetPackageManager — which registers the App Installer and Microsoft.Winget.Source
-    packages even without an interactive logon session (microsoft/winget-cli#6334) — and probes
-    again.
+    `--accept-source-agreements`). When the probe fails it re-probes after each of two bootstrap
+    attempts, cheapest first (issue #265):
+
+      1. Register the Microsoft.DesktopAppInstaller package already staged on this machine for this
+         account (Register-WingetAppInstallerForUser) — no download, no framework dependency
+         deployment.
+      2. Repair-WinGetPackageManager, which registers the App Installer and Microsoft.Winget.Source
+         packages even without an interactive logon session (microsoft/winget-cli#6334), but which
+         can be blocked outright by a 0x80073D06 dependency downgrade rejection — hence the ordering.
 .PARAMETER WhatIf
     When specified, only reports intended actions without executing.
 .RETURNS
@@ -3510,18 +3712,27 @@ function Initialize-WingetSourcesForUser {
         Write-WarningMessage "Winget source update failed with exit code: $($probe.ExitCode)"
     }
 
+    # Cheapest rung first: register the App Installer payload already staged on this machine for this
+    # account. On a cross-user elevation that alone can restore winget with no download at all, and
+    # it sidesteps the 0x80073D06 dependency rejection that can abort the repair cmdlet outright
+    # (issue #265).
+    if (Register-WingetAppInstallerForUser) {
+        $probe = Invoke-WingetSourceProbe
+        if ($probe.Succeeded) {
+            Write-Success 'Winget sources initialized for this account after registering App Installer.'
+            return $true
+        }
+    }
+
     # Bootstrap via the WinGet PowerShell module: unlike winget's own first-use bootstrap (and
     # unlike a plain Add-AppxPackage), Repair-WinGetPackageManager registers the App Installer and
     # Microsoft.Winget.Source packages for the current account even without an interactive logon
     # session (microsoft/winget-cli#6334).
+    $downgradeRejected = $false
     if (Get-Command Repair-WinGetPackageManager -ErrorAction SilentlyContinue) {
         Write-Info 'Bootstrapping winget for this account via Repair-WinGetPackageManager...'
-        try {
-            Repair-WinGetPackageManager -Latest -Force -ErrorAction Stop
-        }
-        catch {
-            Write-WarningMessage "Repair-WinGetPackageManager failed: $_"
-        }
+        $repair = Invoke-WingetPackageManagerRepair
+        $downgradeRejected = [bool]$repair.DowngradeRejected
 
         $probe = Invoke-WingetSourceProbe
         if ($probe.Succeeded) {
@@ -3534,6 +3745,9 @@ function Initialize-WingetSourcesForUser {
     }
 
     Write-WarningMessage "Winget sources could not be initialized for '$processUser'. Installations may fail with 0x80073D19."
+    if ($downgradeRejected) {
+        Write-WarningMessage 'Fix: update App Installer from the Microsoft Store on this machine (the WinGet release this module can deploy is older than a framework package already installed here), then re-run this script.'
+    }
     if ($isCrossUserElevation) {
         Write-WarningMessage "Fix: log on to Windows interactively as '$processUser' once (this registers winget for that account), or run 'winget source update' from any session running as '$processUser', then re-run this script."
     }


### PR DESCRIPTION
Fixes #265

## The bug

On a real cross-user elevation run (elevated as `admin-jmaffiola` on a user's Windows 11 Pro machine), winget bootstrap failed like this:

```
Winget is not available. Bootstrapping it via Repair-WinGetPackageManager...
Repair-WinGetPackageManager failed: Deployment failed with HRESULT: 0x80073D06, The package could not be installed because a higher version of this package is already installed.

Windows cannot install package Microsoft.WindowsAppRuntime.1.8_8000.616.304.0_x64__8wekyb3d8bbwe because it has version 8000.616.304.0. A higher version 8000.921.1539.0 of this package is already installed.
. Falling back to App Installer download...
Winget is not available. Attempting to install Microsoft App Installer...
Web request status [Downloaded: 10.1 MB of 206.7 MB]
```

`Repair-WinGetPackageManager -Latest -Force` deploys the framework dependencies pinned to the WinGet release it installs. This machine already had a **newer** `Microsoft.WindowsAppRuntime.1.8` - routine wherever Teams / Phone Link / an MDM push updates it independently - so AppX rejected the downgrade with `0x80073D06` (`ERROR_INSTALL_PACKAGE_DOWNGRADE`) and the cmdlet aborted **before** registering App Installer.

The run does eventually finish: it falls through to the `aka.ms/getwinget` last resort, which succeeds. So this is a cost-and-legibility bug, not a dead end - but the account needed nothing more than a per-user registration of a package **already staged on the machine**, and it paid a ~200 MB download plus a wall of AppX errors that reads like a broken machine.

## The fix

Reorder both `Repair-WinGetPackageManager` call sites onto a cheapest-first ladder instead of leading with the heaviest, most fragile rung.

1. **`Register-WingetAppInstallerForUser`** (new, private) - registers the `Microsoft.DesktopAppInstaller` package already staged on the machine for the current account: `Add-AppxPackage -RegisterByFamilyName`, falling back to `-Register` against each candidate's `AppXManifest.xml`. No download, no dependency deployment. This is the direct fix for the cross-user elevation case the module already handles for sources and agreements (#104 / #150 / #159): the interactive user has a working winget, the elevating admin account has no per-user registration and therefore no `winget.exe` app-execution alias.
2. **`Invoke-WingetPackageManagerRepair`** (new, private) - shared unforced-then-forced wrapper, so the two call sites cannot drift apart on retry policy (same reasoning that made `Test-WingetSourceHealth` shared in #177). The unforced pass runs first so the cmdlet can skip dependencies already present at an equal or newer version; `-Force` is still attempted after an unrelated failure, since it remains the documented remedy for a broken App Installer registration.
3. **`Test-AppxDowngradeRejection`** (new, private) - classifies `0x80073D06` off the locale-independent hex HRESULT (the English phrasing is extra coverage only, per the existing notes in #177/#180). A downgrade rejection short-circuits: `-Force` cannot fix a rejection *caused by* a newer dependency already being present, and retrying would burn a second multi-hundred-megabyte download.
4. `Initialize-WingetSourcesForUser` additionally names the dependency conflict in its remediation advice. The `aka.ms/getwinget` download stays the unchanged last resort.

## Assumption worth flagging

The unforced-before-forced ordering is inferred from the failure itself - the error names the *release-pinned* dependency version, which is `-Force` behaviour - not from documented `Repair-WinGetPackageManager` semantics, which do not spell out how `-Force` interacts with dependency version comparison. If it turns out unforced behaves identically, rung 1 is still the load-bearing fix and the ordering costs nothing.

## Testing

```bash
pwsh -NoProfile -Command "Import-Module Pester -MinimumVersion 6.0.0 -MaximumVersion 6.999.999; Invoke-Pester ./tests"
```

`350 passed, 0 failed, 3 skipped` under Pester 6.x. 17 new tests cover the three helpers (family-name registration, manifest fallback, nothing-staged, all-forms-fail, `-AllUsers` enumeration and its refusal fallback, the classifier including the real failure text and the unrelated `0x80073D19`, and each repair-escalation branch) plus both reordered call sites.

Existing call-site tests mock `Register-WingetAppInstallerForUser` as a seam rather than mocking `Get-AppxPackage`/`Add-AppxPackage` directly, so a missed mock can never reach the real AppX deployment cmdlets (the #181 safety-net principle).

`winget-app-install.ps1` regenerated; `build/Build-WingetInstallScript.ps1 -Check` passes.