### PR TITLE
docs: document the MSI path in the readme's PowerShell 7 bootstrap blurb

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,11 +6,21 @@ A one-line guide for running the installer.
 
 > **Runs on PowerShell 7+ (`pwsh`), but bootstraps itself from Windows PowerShell 5.1.** The
 > installer's logic requires PowerShell 7. Run from the built-in Windows PowerShell 5.1
-> (`powershell.exe`) — the only shell on a fresh machine — and it finds PowerShell 7 (or
-> installs it via winget, no consent prompt), then relaunches itself under
-> `pwsh` in the same window with your switches forwarded
-> ([#225](https://github.com/J-MaFf/winget-app-setup/issues/225)). A `-WhatIf` run never
-> installs anything — without PowerShell 7 present it just previews the bootstrap.
+> (`powershell.exe`) — the only shell on a fresh machine — and it finds PowerShell 7, or
+> installs it with no consent prompt, then relaunches itself under `pwsh` in the same window
+> with your switches forwarded ([#225](https://github.com/J-MaFf/winget-app-setup/issues/225)).
+> A `-WhatIf` run never installs anything — without PowerShell 7 present it just previews the
+> bootstrap.
+>
+> Installing it takes one of two paths, in order:
+>
+> 1. **winget**, when the invoking account has it.
+> 2. **The official MSI**, when it does not — the usual reason being that you elevated as a
+>    separate admin account, since winget is a per-user MSIX and a never-logged-in account has
+>    no copy of it. This path downloads ~110 MB and then runs `msiexec`, so expect a couple of
+>    minutes; it prints `X of 110.2 MB (N%)` progress lines throughout, and a stalled download
+>    fails with a message rather than waiting forever
+>    ([#263](https://github.com/J-MaFf/winget-app-setup/issues/263)).
 
 From the repository root, execute (after cloning):
 


### PR DESCRIPTION
Fixes #269

The "Run the installer" callout described the 5.1 bootstrap as finding PowerShell 7 "or
installing it via winget" — which names only the first of two install paths.

When the invoking account has no winget, the bootstrap installs the official MSI instead. That
isn't an edge case: winget is a per-user MSIX, so any admin account that has never logged in
interactively has no copy of it, which is the ordinary shape of "elevate as the shop admin on a
user's machine." The readme said nothing about that path, so a reader on it had no
documentation for what they were seeing. That is exactly what happened on a real run on
2026-08-11.

It's worth documenting now that [#263](https://github.com/J-MaFf/winget-app-setup/issues/263)
gave the path visible behavior a reader needs expectations for.

## Change

Split the callout into the existing prose plus a short ordered list:

1. **winget**, when the invoking account has it.
2. **The official MSI**, when it does not — with the reason a reader lands there, the
   ~110 MB / couple-of-minutes expectation, the `X of 110.2 MB (N%)` progress lines, and the
   fact that a stalled download now fails with a message instead of waiting forever.

The second point is the one that earns its place: without it, several minutes of a legitimate
download is indistinguishable from a hang, which is the confusion #263 was filed for.

## Testing

Docs only — no code touched, `winget-app-install.ps1` unchanged, drift check unaffected.
Re-read the rendered blockquote to confirm the nested ordered list and continuation lines format
correctly inside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)